### PR TITLE
Event range

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,25 @@
 
 Clight is a C daemon utility to automagically change screen backlight level to match ambient brightness.  
 Ambient brightness is computed by capturing frames from webcam.  
-Moreover, it can manage your screen temperature, just like redshift does.
+Moreover, it can manage your screen temperature, just like redshift does.  
 
-It is heavily inspired by [calise](http://calise.sourceforge.net/wordpress/), at least in its intents.
+It is heavily inspired by [calise](http://calise.sourceforge.net/wordpress/), at least in its intents.  
 
 It is splitted in 2 modules: clight and clightd.  
 [Clight](https://github.com/FedeDP/Clight/tree/master/clight) is the user service to automagically change screen brightness every N minutes.  
 [Clightd](https://github.com/FedeDP/Clight/tree/master/clightd) is the bus interface that is needed to change screen brightness and to capture webcame frames.  
 
 For more details, check each module README.
+
+## Deb packages
+Deb packages for amd64 architecture are provided. You can find it inside [Debian](https://github.com/FedeDP/Clight/blob/master/COPYING) folder.  
+Moreover, you can very easily build your own packages, if aforementioned packages happen to be outdated.  
+You only need to move to your desired module (eg: clightd), and issue:
+
+    $ make deb
+
+A deb file will be created in [Debian](https://github.com/FedeDP/Clight/blob/master/COPYING) folder.  
+Please note that while i am using Debian testing at my job, i am developing clight from archlinux.  
+Thus, you can encounter some packaging issues. Please, report back.  
 
 This softwares are distributed with GPL license, see [COPYING](https://github.com/FedeDP/Clight/blob/master/COPYING) file for more informations.

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ It is splitted in 2 modules: clight and clightd.
 
 For more details, check each module README.
 
-This softwares are distributed with a GPL license, see [COPYING](https://github.com/FedeDP/Clight/blob/master/COPYING) file for more informations.
+This softwares are distributed with GPL license, see [COPYING](https://github.com/FedeDP/Clight/blob/master/COPYING) file for more informations.

--- a/clight/DEBIAN/control
+++ b/clight/DEBIAN/control
@@ -1,0 +1,8 @@
+Package: clight
+Version: 0.1
+Section: base
+Priority: optional
+Architecture: amd64
+Depends: libpopt0, libsystemd0, libxcb-dpms0
+Maintainer: Federico Di Pierro <nierro92@gmail.com>
+Description: Clightd bus interface to set screen brightness and gamma.

--- a/clight/README.md
+++ b/clight/README.md
@@ -19,6 +19,7 @@ A systemd user unit is shipped too. Just run "systemctl --user enable clight.ser
 * nice log file, placed in $HOME/.clight.log
 * --sunrise/--sunset times user-specified support: gamma nightly temp will be setted at sunset time, daily temp at sunrise time.
 * more frequent captures inside "events": an event starts 30mins before sunrise/sunset and ends 30mins after sunrise/sunset.
+* gamma correction tool support can be disabled at runtime (--no-gamma cmdline switch)
 
 ### Valgrind is run with:
     

--- a/clight/README.md
+++ b/clight/README.md
@@ -20,11 +20,11 @@ A systemd user unit is shipped too. Just run "systemctl --user enable clight.ser
 * --sunrise/--sunset times user-specified support: gamma nightly temp will be setted at sunset time, daily temp at sunrise time.
 * more frequent captures inside "events": an event starts 30mins before sunrise/sunset and ends 30mins after sunrise/sunset.
 
-Valgrind is run with:
+### Valgrind is run with:
     
     $ alias valgrind='valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all -v'
     
-cppcheck is run with:
+### Cppcheck is run with:
 
     $  cppcheck --enable=style --enable=performance --enable=unusedFunction 
 
@@ -34,10 +34,11 @@ There is no more option file support through libconfig as cmd line options alrea
 Moreover, with [systemd unit conf files](https://wiki.archlinux.org/index.php/systemd#Drop-in_files), is really easy to reach same behaviour (ie: systemd unit launched with certain cmdline args).
 
 ## Build instructions:
+Build and install:
 
     $ make
     # make install
 
-To uninstall:
+Uninstall:
 
     # make uninstall

--- a/clight/README.md
+++ b/clight/README.md
@@ -1,15 +1,15 @@
 This is clight user service source code.
 
-It currently needs:
+## It currently needs:
 * libxcb (xcb.h, xcb/dpms.h)
 * libsystemd (systemd/sd-bus.h)
 * libpopt (popt.h)
 
 A systemd user unit is shipped too. Just run "systemctl --user enable clight.service" and reboot.
 
-Current features:
+## Current features:
 * very lightweight
-* fully valgrind clean
+* fully valgrind and cppcheck clean
 * external signals catching (sigint/sigterm)
 * dpms support: it will check current screen powersave level and won't do anything if screen is currently off.
 * a single capture mode from cmdline
@@ -17,13 +17,23 @@ Current features:
 * geoclue2 support: when launched without [--lat|--lon] parameters, if geoclue2 is available, it will use it to get user location updates.
 * different nightly and daily captures timeout (by default 45mins during the night and 10mins during the day; both configurable.)
 * nice log file, placed in $HOME/.clight.log
+* --sunrise/--sunset times user-specified support: gamma nightly temp will be setted at sunset time, daily temp at sunrise time.
+* more frequent captures inside "events": an event starts 30mins before sunrise/sunset and ends 30mins after sunrise/sunset.
+
+Valgrind is run with:
+    
+    $ alias valgrind='valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all -v'
+    
+cppcheck is run with:
+
+    $  cppcheck --enable=style --enable=performance --enable=unusedFunction 
 
 For cmdline options, check clight [-?|--help] [--usage].
 
 There is no more option file support through libconfig as cmd line options already expose every setting.  
 Moreover, with [systemd unit conf files](https://wiki.archlinux.org/index.php/systemd#Drop-in_files), is really easy to reach same behaviour (ie: systemd unit launched with certain cmdline args).
 
-Build instructions:
+## Build instructions:
 
     $ make
     # make install

--- a/clight/README.md
+++ b/clight/README.md
@@ -2,7 +2,7 @@ This is clight user service source code.
 
 ## It currently needs:
 * libxcb (xcb.h, xcb/dpms.h)
-* libsystemd (systemd/sd-bus.h)
+* libsystemd >= 221 (systemd/sd-bus.h)
 * libpopt (popt.h)
 
 A systemd user unit is shipped too. Just run "systemctl --user enable clight.service" and reboot.
@@ -22,14 +22,14 @@ A systemd user unit is shipped too. Just run "systemctl --user enable clight.ser
 * gamma correction tool support can be disabled at runtime (--no-gamma cmdline switch)
 
 ### Valgrind is run with:
-    
+
     $ alias valgrind='valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all -v'
-    
+
 ### Cppcheck is run with:
 
-    $  cppcheck --enable=style --enable=performance --enable=unusedFunction 
+    $  cppcheck --enable=style --enable=performance --enable=unusedFunction
 
-For cmdline options, check clight [-?|--help] [--usage].
+For cmdline options, check clight [-?|--help] [--usage].  
 
 There is no more option file support through libconfig as cmd line options already expose every setting.  
 Moreover, with [systemd unit conf files](https://wiki.archlinux.org/index.php/systemd#Drop-in_files), is really easy to reach same behaviour (ie: systemd unit launched with certain cmdline args).

--- a/clight/TODO.md
+++ b/clight/TODO.md
@@ -4,3 +4,4 @@ TODO before release:
 - [ ] follow https://github.com/systemd/systemd/issues/5654 (next systemd release?) (need to make a PR upstream)
 - [ ] fix algorithm to set screen brightness based on ambient brightness (needs real world testing)
 - [ ] avoid printing "%d gamma value set" when smooth-transitioning
+- [ ] smooth_transition is useless. Just set a --no-smooth_transition flag (conf.no_smooth_transition).

--- a/clight/TODO.md
+++ b/clight/TODO.md
@@ -1,10 +1,12 @@
 TODO before release:
 
 ## High Priority:
-- [ ] Very frequent capture at "event" changing (ie: during sunset or sunrise)
+- [x] Very frequent capture at "event" changing (ie: during sunset or sunrise) -> ci siamo quasi
+- [x] add doc for gamma (it is kind of chaotic)
+- [x] fix FIXME in gamma.c
 
 ## Mid Priority:
-- [ ] add settable timers for gamma temp events (eg --sunset 7:00 --sunshine 19:30)
+- [x] add settable timers for gamma temp events (eg --sunset 7:00 --sunshine 19:30)
 - [x] add gpl license file
 
 ## Low Priority:

--- a/clight/TODO.md
+++ b/clight/TODO.md
@@ -3,5 +3,6 @@ TODO before release:
 ## Low Priority:
 - [ ] follow https://github.com/systemd/systemd/issues/5654 (next systemd release?) (need to make a PR upstream)
 - [ ] fix algorithm to set screen brightness based on ambient brightness (needs real world testing)
-- [ ] avoid printing "%d gamma value set" when smooth-transitioning
-- [ ] smooth_transition is useless. Just set a --no-smooth_transition flag (conf.no_smooth_transition).
+- [x] avoid printing "%d gamma value set" when smooth-transitioning
+- [x] smooth_transition is useless. Just set a --no-smooth_transition flag (conf.no_smooth_transition).
+- [x] add debian/ubuntu deb package script

--- a/clight/TODO.md
+++ b/clight/TODO.md
@@ -8,6 +8,8 @@ TODO before release:
 ## Mid Priority:
 - [x] add settable timers for gamma temp events (eg --sunset 7:00 --sunshine 19:30)
 - [x] add gpl license file
+- [x] avoid printing "MODULE x destroyed" if it has never been inited
+- [ ] add a "--no-gamma" cmdline switch to disable gamma correction tool.
 
 ## Low Priority:
 - [ ] follow https://github.com/systemd/systemd/issues/5654 (next systemd release?) (need to make a PR upstream)

--- a/clight/TODO.md
+++ b/clight/TODO.md
@@ -1,16 +1,6 @@
 TODO before release:
 
-## High Priority:
-- [x] Very frequent capture at "event" changing (ie: during sunset or sunrise) -> ci siamo quasi
-- [x] add doc for gamma (it is kind of chaotic)
-- [x] fix FIXME in gamma.c
-
-## Mid Priority:
-- [x] add settable timers for gamma temp events (eg --sunset 7:00 --sunshine 19:30)
-- [x] add gpl license file
-- [x] avoid printing "MODULE x destroyed" if it has never been inited
-- [ ] add a "--no-gamma" cmdline switch to disable gamma correction tool.
-
 ## Low Priority:
 - [ ] follow https://github.com/systemd/systemd/issues/5654 (next systemd release?) (need to make a PR upstream)
 - [ ] fix algorithm to set screen brightness based on ambient brightness (needs real world testing)
+- [ ] avoid printing "%d gamma value set" when smooth-transitioning

--- a/clight/inc/commons.h
+++ b/clight/inc/commons.h
@@ -1,3 +1,6 @@
+#define __USE_XOPEN
+
+#include <time.h>
 #include <stdlib.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -6,31 +9,35 @@
 #include <stdio.h>
 #include <stdint.h>
 #include <errno.h>
-#include <time.h>
 #include <stdarg.h>
 #include <poll.h>
 #include <math.h>
 
 enum modules { CAPTURE_IX, GAMMA_IX, LOCATION_IX, SIGNAL_IX, DPMS_IX, MODULES_NUM };
 
-enum states { DAY, NIGHT, EVENT, UNKNOWN, SIZE };
+enum states { DAY, NIGHT, EVENT, UNKNOWN, SIZE_STATES };
+
+enum events { SUNRISE, SUNSET, SIZE_EVENTS };
 
 struct config {
     int num_captures;
     int single_capture_mode;
-    int timeout[SIZE]; // sizeof enum states
-    char dev_name[PATH_MAX + 1];
-    char screen_path[PATH_MAX + 1];
-    int temp[SIZE]; // sizeof enum states DAY, NIGHT only
+    int timeout[SIZE_STATES]; // sizeof enum states
+    char *dev_name;
+    char *screen_path;
+    int temp[SIZE_STATES]; // sizeof enum states DAY, NIGHT only
     int smooth_transition;
     double lat;
     double lon;
+    char *events[2];
 };
 
 struct state {
     int quit;
     enum states time; // whether it is day or night time
-    time_t next_event;
+    time_t events[SIZE_EVENTS]; // today events (sunrise/sunset)
+    enum events next_event; // next event index
+    int event_time_range;
 };
 
 struct poll_s {

--- a/clight/inc/commons.h
+++ b/clight/inc/commons.h
@@ -30,6 +30,7 @@ struct config {
     double lat;
     double lon;
     char *events[2];
+    int no_gamma;
 };
 
 struct state {

--- a/clight/inc/commons.h
+++ b/clight/inc/commons.h
@@ -26,7 +26,7 @@ struct config {
     char *dev_name;
     char *screen_path;
     int temp[SIZE_STATES]; // sizeof enum states DAY, NIGHT only
-    int smooth_transition;
+    int no_smooth_transition;
     double lat;
     double lon;
     char *events[2];

--- a/clight/inc/gamma.h
+++ b/clight/inc/gamma.h
@@ -1,5 +1,3 @@
-#include <bits/time.h>
-
 #include "bus.h"
 
 void init_gamma(void);

--- a/clight/inc/opts.h
+++ b/clight/inc/opts.h
@@ -1,3 +1,4 @@
 #include "log.h"
 
 void init_opts(int argc, char *argv[]);
+void destroy_opts(void);

--- a/clight/makefile
+++ b/clight/makefile
@@ -2,8 +2,11 @@ BINDIR = /usr/bin
 BINNAME = clight
 SYSTEMDDIR = /usr/lib/systemd/user/
 SYSTEMDUNIT = clight.service
+DEBIANDIR = ./Clight
+DEBOUTPUTDIR = ../Debian
 EXTRADIR = Extra
 RM = rm -f
+RMDIR = rm -rf
 INSTALL = install -p
 INSTALL_PROGRAM = $(INSTALL) -m755
 INSTALL_DATA = $(INSTALL) -m644
@@ -39,6 +42,22 @@ clight-debug: objects-debug
 
 clean:
 	@cd $(SRCDIR); $(RM) *.o
+
+deb: all install-deb build-deb clean-deb
+
+install-deb: DESTDIR=$(DEBIANDIR)
+install-deb: install
+
+build-deb:
+	$(info copying debian build script.)
+	@cp -r DEBIAN/ $(DEBIANDIR)
+	@$(INSTALL_DIR) $(DEBOUTPUTDIR)
+	$(info creating debian package.)
+	@dpkg-deb --build $(DEBIANDIR) $(DEBOUTPUTDIR)
+
+clean-deb:
+	$(info cleaning up.)
+	@$(RMDIR) $(DEBIANDIR)
 
 install:
 	$(info installing bin.)

--- a/clight/src/brightness.c
+++ b/clight/src/brightness.c
@@ -9,6 +9,8 @@ static double set_brightness(double perc);
 static double capture_frame_brightness(void);
 static double compute_avg_brightness(void);
 
+static int inited;
+
 /*
  * Storage struct for our needed variables.
  */
@@ -42,6 +44,7 @@ void init_brightness(void) {
             int fd = start_timer(CLOCK_MONOTONIC, 1);
             set_pollfd(fd, CAPTURE_IX, brightness_cb);
             INFO("Brightness module started.\n");
+            inited = 1;
         }
     }
 }
@@ -164,12 +167,13 @@ static double compute_avg_brightness(void) {
 }
 
 void destroy_brightness(void) {
-    if (br.values) {
-        free(br.values);
+    if (inited) { 
+        if (br.values) {
+            free(br.values);
+        }
+        if (main_p.p[CAPTURE_IX].fd > 0) {
+            close(main_p.p[CAPTURE_IX].fd);
+        }
+        INFO("Brightness module destroyed.\n");
     }
-
-    if (main_p.p[CAPTURE_IX].fd > 0) {
-        close(main_p.p[CAPTURE_IX].fd);
-    }
-    INFO("Brightness module destroyed.\n");
 }

--- a/clight/src/brightness.c
+++ b/clight/src/brightness.c
@@ -36,9 +36,9 @@ void init_brightness(void) {
         get_current_brightness();
 
         /* Initialize our brightness values array */
-        if (!state.quit && !(br.values = calloc(conf.num_captures, sizeof(double)))) {
+        if (!(br.values = calloc(conf.num_captures, sizeof(double)))) {
             state.quit = 1;
-        } else {
+        } else if (!state.quit) {
             int fd = start_timer(CLOCK_MONOTONIC, 1);
             set_pollfd(fd, CAPTURE_IX, brightness_cb);
             INFO("Brightness module started.\n");
@@ -53,6 +53,9 @@ static void brightness_cb(void) {
         read(main_p.p[CAPTURE_IX].fd, &t, sizeof(uint64_t));
     }
     do_capture();
+    if (conf.single_capture_mode) {
+        state.quit = 1;
+    }
 }
 
 /**
@@ -165,7 +168,7 @@ void destroy_brightness(void) {
         free(br.values);
     }
 
-    if (main_p.p[CAPTURE_IX].fd != -1) {
+    if (main_p.p[CAPTURE_IX].fd > 0) {
         close(main_p.p[CAPTURE_IX].fd);
     }
     INFO("Brightness module destroyed.\n");

--- a/clight/src/bus.c
+++ b/clight/src/bus.c
@@ -2,6 +2,8 @@
 
 static void free_bus_structs(sd_bus_error *err, sd_bus_message *m, sd_bus_message *reply);
 
+static int inited;
+
 /*
  * Open our bus
  */
@@ -11,6 +13,7 @@ void init_bus(void) {
         ERROR("Failed to connect to system bus: %s\n", strerror(-r));
         state.quit = 1;
     } else {
+        inited = 1;
         INFO("Bus support started.\n");
     }
 }
@@ -180,8 +183,10 @@ int check_err(int r, sd_bus_error *err) {
  * Close bus.
  */
 void destroy_bus(void) {
-    if (bus) {
-        sd_bus_flush_close_unref(bus);
+    if (inited) {
+        if (bus) {
+            sd_bus_flush_close_unref(bus);
+        }
+        INFO("Bus destroyed.\n");
     }
-    INFO("Bus destroyed.\n");
 }

--- a/clight/src/clight.c
+++ b/clight/src/clight.c
@@ -21,8 +21,6 @@
  *
  * END_COMMON_COPYRIGHT_HEADER */
 
-#define _GNU_SOURCE
-
 #include "../inc/bus.h"
 #include "../inc/brightness.h"
 #include "../inc/gamma.h"
@@ -64,12 +62,9 @@ static void init(int argc, char *argv[]) {
     open_log();
     init_opts(argc, argv);
     init_bus();
-    for (int i = 0; i < MODULES_NUM && !state.quit; i++) {
+    const int limit = conf.single_capture_mode ? 1 : MODULES_NUM;
+    for (int i = 0; i < limit && !state.quit; i++) {
         init_module[i]();
-    }
-    if (!state.quit && conf.single_capture_mode) {
-        main_p.cb[CAPTURE_IX]();
-        state.quit = 1;
     }
 }
 
@@ -77,10 +72,12 @@ static void init(int argc, char *argv[]) {
  * Free every used resource
  */
 static void destroy(void) {
-    for (int i = 0; i < MODULES_NUM; i++) {
+    const int limit = conf.single_capture_mode ? 1 : MODULES_NUM;
+    for (int i = 0; i < limit; i++) {
         destroy_module[i]();
     }
     destroy_bus();
+    destroy_opts();
     close_log();
 }
 

--- a/clight/src/dpms.c
+++ b/clight/src/dpms.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 
 static xcb_connection_t *connection;
-static int dpms_enabled;
+static int dpms_enabled, inited;
 
 /**
  * Checks through xcb if DPMS is enabled for this xscreen
@@ -21,7 +21,7 @@ void init_dpms(void) {
         if (info->state) {
             dpms_enabled = 1;
         }
-
+        inited = 1;
         free(info);
     }
     INFO("Dpms support started.\n");
@@ -57,8 +57,10 @@ int get_screen_dpms(void) {
 }
 
 void destroy_dpms(void) {
-    if (connection) {
-        xcb_disconnect(connection);
+    if (inited) {
+        if (connection) {
+            xcb_disconnect(connection);
+        }
+        INFO("Dpms destroyed.\n");
     }
-    INFO("Dpms destroyed.\n");
 }

--- a/clight/src/gamma.c
+++ b/clight/src/gamma.c
@@ -2,8 +2,7 @@
 
 #define ZENITH -0.83
 #define SMOOTH_TRANSITION_TIMEOUT 300 * 1000 * 1000
-
-enum events { SUNRISE, SUNSET };
+#define EVENT_DURATION 30 * 60
 
 static void gamma_cb(void);
 static void check_gamma(void);
@@ -12,17 +11,27 @@ static double radToDeg(const double angleRad);
 static float to_hours(const float rad);
 static int calculate_sunrise_sunset(const float lat, const float lng,
                                     time_t *tt, enum events event, int tomorrow);
-static void get_next_gamma_event(const float lat, const float lon);
+static void get_gamma_events(time_t *now, const float lat, const float lon, int day);
+static void check_next_event(time_t *now);
+static void check_state(time_t *now);
 static int set_temp(int temp);
 
 void init_gamma(void) {
-    int gamma_timerfd = start_timer(CLOCK_REALTIME, 0);
+    int initial_timeout = 0;
+    /* 
+     * if both sunrise and sunset times are passed
+     * through cmdline opts, start immediately gamma module.
+     */
+    if (conf.events[SUNRISE] && conf.events[SUNSET]) {
+        initial_timeout = 1;
+    }
+    int gamma_timerfd = start_timer(CLOCK_REALTIME, initial_timeout);
     set_pollfd(gamma_timerfd, GAMMA_IX, gamma_cb);
     INFO("Gamma module started.\n");
 }
 
 void destroy_gamma(void) {
-    if (main_p.p[GAMMA_IX].fd != -1) {
+    if (main_p.p[GAMMA_IX].fd > 0) {
         close(main_p.p[GAMMA_IX].fd);
     }
     INFO("Gamma module destroyed.\n");
@@ -36,28 +45,55 @@ static void gamma_cb(void) {
 }
 
 /*
- * check current period of time (day or night) and next event (sunrise/sunset).
- * Then call set_temp with correct temp, given current state(night or day).
+ * checks next day events (or current day if clight has started right now).
+ * Then, if needed (ie: first time this func is called or when state.time changed),
+ * calls set_temp with correct temp, given current state(night or day).
  * It returns 0 if: smooth_transition is off or desired temp has finally been setted (after transitioning).
  * If it returns 0, reset transitioning flag and set next event timeout.
  * Else, set a timeout for smooth transition and set transitioning flag to 1.
+ * If ret == 0, it can also mean we haven't called set_temp, and this means an
+ * "event" timeout elapsed. If old_state != state.time (ie: if we entered or left EVENT state),
+ * set new CAPTURE_IX correct timeout according to new state.
  */
 static void check_gamma(void) {
-    static int transitioning = 0;
-
+    static int transitioning = 0, first_time = 1;
+    time_t t;
+    enum states old_state = state.time;
+    
+    /* 
+     * Only if we're not doing a smooth transition
+     */
     if (!transitioning) {
-        get_next_gamma_event(conf.lat, conf.lon);
+        t = time(NULL);        
+        /* 
+         * first time clight is started, get_gamma_events will poll today events.
+         * Then, it will be called every day after end of last event (ie: sunset + 30mins)
+         */ 
+        get_gamma_events(&t, conf.lat, conf.lon, state.events[SUNSET] != 0);
+        if (state.quit) {
+            return;
+        }
     }
 
-    int ret = set_temp(conf.temp[state.time]);
-    if (state.quit) {
-        return;
+    int ret = 0;
+    if (transitioning || state.event_time_range == EVENT_DURATION || first_time) {
+        first_time = 0;
+        ret = set_temp(conf.temp[state.time]);
+        if (state.quit) {
+            return;
+        }
     }
 
     if (ret == 0) {
-        INFO("Next gamma alarm due to: %s", ctime(&(state.next_event)));
-        set_timeout(state.next_event, 0, main_p.p[GAMMA_IX].fd, TFD_TIMER_ABSTIME);
+        t = state.events[state.next_event] + state.event_time_range;
+        INFO("Next gamma alarm due to: %s", ctime(&t));
+        set_timeout(state.events[state.next_event] + state.event_time_range, 0, main_p.p[GAMMA_IX].fd, TFD_TIMER_ABSTIME);
         transitioning = 0;
+        
+        /* if we entered/left an event, set correct timeout to CAPTURE_IX */
+        if (old_state != state.time) {
+            set_timeout(conf.timeout[state.time], 0, main_p.p[CAPTURE_IX].fd, 0);
+        }
     } else {
         // here, set a timeout of 300ms from now for smooth gamma transition
         set_timeout(0, SMOOTH_TRANSITION_TIMEOUT, main_p.p[GAMMA_IX].fd, 0);
@@ -82,17 +118,38 @@ static float to_hours(const float rad) {
 /*
  * Just a small function to compute sunset/sunrise for today (or tomorrow).
  * See: http://stackoverflow.com/questions/7064531/sunrise-sunset-times-in-c
+ * IF conf.events are both set, it means sunrise/sunset times are user-setted.
+ * So, only store in *tt their corresponding time_t values.
  */
 static int calculate_sunrise_sunset(const float lat, const float lng, time_t *tt, enum events event, int tomorrow) {
     // 1. compute the day of the year (timeinfo->tm_yday below)
     time(tt);
-    struct tm *timeinfo = gmtime(tt);
+    struct tm *timeinfo;
+    
+    if (conf.events[SUNRISE] && conf.events[SUNSET]) {
+        timeinfo = localtime(tt); 
+    } else { 
+        timeinfo = gmtime(tt); 
+    }
     if (!timeinfo) {
         return -1;
     }
     // if needed, set tomorrow
     timeinfo->tm_yday += tomorrow;
     timeinfo->tm_mday += tomorrow;
+    
+    /* If user provided a sunrise/sunset time, use them */
+    if (conf.events[SUNRISE] && conf.events[SUNSET]) {
+        char *s = strptime(conf.events[event], "%R", timeinfo);
+        if (!s) {
+            ERROR("Wrong sunrise/sunset time setted by a cmdline arg. Leaving.\n");
+            state.quit = 1;
+            return -1;
+        }
+        timeinfo->tm_sec = 0;
+        *tt = mktime(timeinfo);
+        return 0;
+    }
 
     // 2. convert the longitude to hour value and calculate an approximate time
     float lngHour = to_hours(lng);
@@ -147,12 +204,11 @@ static int calculate_sunrise_sunset(const float lat, const float lng, time_t *tt
 
     double hours;
     double minutes = modf(UT, &hours) * 60;
-    double seconds = modf(minutes, &minutes) * 60;
 
     // set correct values
     timeinfo->tm_hour = hours;
     timeinfo->tm_min = minutes;
-    timeinfo->tm_sec = seconds;
+    timeinfo->tm_sec = 0;
 
     // store in user provided ptr correct data
     *tt = timegm(timeinfo);
@@ -171,33 +227,90 @@ static int calculate_sunset(const float lat, const float lng, time_t *tt, int to
 }
 
 /*
- * Tries to understand next event:
- * first computes today's sunrise and sunset.
- * If now is < sunrise, next event is today's sunrise and we're during the night.
- * Otherwise, if now is < sunset, we're during the day and next event is sunset.
- * Else, next event will be tomorrow's sunrise and we're in night time.
+ * day -> will be 0 first time this func is called, else 1 (tomorrow).
+ * Stores day sunrise/sunset events only if this is first time it is called,
+ * or of today's sunset event is finished.
+ * Firstly computes day's sunrise and sunset; then calls check_next_event and check_state to
+ * update global state.next_event and state.time variables according to new state.
+ * Note that "-1" is because it seems timerfd receives timer end circa 1s in advance.
+ * Probably it is just some ms in advance, but rounding it to seconds returns 1s in advance.
  */
-static void get_next_gamma_event(const float lat, const float lon) {
-    time_t t, now;
-
-    time(&now);
-
-    // if sunrise time is after now, set next alarm
-    if (calculate_sunrise(lat, lon, &t, 0) == 0 && t > now) {
-        state.time = NIGHT;
-    } else if (calculate_sunset(lat, lon, &t, 0) == 0 && t > now) {
-        state.time = DAY;
-    } else if (calculate_sunrise(lat, lon, &t, 1) == 0) {
-        // we are after sunset time for today. Let's check tomorrow's sunrise
-        state.time = NIGHT;
-    } else {
-        // no sunrise/sunset could be found.
-        state.time = UNKNOWN;
-        // set an alarm to recheck gamma event after 12h...
-        t = now + 12 * 60 * 60;
-        ERROR("Failed to retrieve sunrise/sunset informations.\n");
+static void get_gamma_events(time_t *now, const float lat, const float lon, int day) {
+    time_t t;
+        
+    /* only every new day, after latest event of today finished */
+    if (*now >= state.events[SUNSET] + EVENT_DURATION - 1) {
+        if (calculate_sunset(lat, lon, &t, day) == 0) {
+            if (*now > t + EVENT_DURATION - 1) {
+                /*
+                 * we're between today's sunrise and tomorrow sunrise.
+                 * rerun function with tomorrow.
+                 * Useful only first time clight is started 
+                 * (ie: if it is started at night time)
+                 */
+                return get_gamma_events(now, lat, lon, ++day);
+            }
+            state.events[SUNSET] = t;
+        } else {
+            state.events[SUNSET] = -1;
+        }
+    
+        if (calculate_sunrise(lat, lon, &t, day) == 0) {
+            state.events[SUNRISE] = t;
+        } else {
+            state.events[SUNRISE] = -1;
+        }
+    
+        if (state.events[SUNRISE] == -1 && state.events[SUNSET] == -1) {
+            // no sunrise/sunset could be found.
+            state.time = UNKNOWN;
+            // set an alarm to recheck gamma event after 12h...
+            state.events[SUNRISE] = *now + 12 * 60 * 60;
+            ERROR("Failed to retrieve sunrise/sunset informations.\n");
+        }
     }
-    state.next_event = t;
+    check_next_event(now);
+    check_state(now);
+}
+
+/*
+ * Updates state.next_event global var, according to now time_t value.
+ * Note that "-1" is because it seems timerfd receives timer end circa 1s in advance.
+ */
+static void check_next_event(time_t *now) {
+    if (*now < state.events[SUNRISE] + EVENT_DURATION - 1 || state.events[SUNSET] == -1) {
+        state.next_event = SUNRISE;
+    } else {
+        state.next_event = SUNSET;
+    }
+}
+
+/*
+ * Updates state.time global var, according to now time_t value.
+ * Note that "-1" is because it seems timerfd receives timer end circa 1s in advance.
+ * If we're inside an event, checks which side of the events we're in 
+ * (to understand which conf.temp is correct for this state).
+ * Then sets state.event_time_range accordingly; ie: 30mins before event, if we're not inside an event;
+ * 0 if we just entered an event (so next_event has to be exactly event time, to set new temp),
+ * 30mins after event to remove EVENT state.
+ */
+static void check_state(time_t *now) {
+    if (labs(state.events[state.next_event] - *now) <= EVENT_DURATION) {
+        int event_t;
+
+        if (state.events[state.next_event] - *now > 1) {
+            event_t = state.next_event;
+            state.event_time_range = 0;
+        } else {
+            event_t = !state.next_event;
+            state.event_time_range = EVENT_DURATION;
+        }
+        conf.temp[EVENT] = event_t == SUNRISE ? conf.temp[NIGHT] : conf.temp[DAY];
+        state.time = EVENT;
+    } else {
+        state.time = state.next_event == SUNRISE ? NIGHT : DAY;
+        state.event_time_range = -EVENT_DURATION; // 30mins before event
+    }
 }
 
 /*

--- a/clight/src/location.c
+++ b/clight/src/location.c
@@ -15,6 +15,7 @@ static void geoclue_client_start(void);
 static void geoclue_client_stop(void);
 
 static char client[PATH_MAX + 1];
+static int inited;
 
 /*
  * init location:
@@ -30,10 +31,11 @@ static char client[PATH_MAX + 1];
  */
 void init_location(void) {    
     /* 
-     * if sunrise/sunset times are passed through cmdline,
+     * if sunrise/sunset times are passed through cmdline, 
+     * or gamma support is disabled,
      * there is no need to load location module.
      */
-    if (!conf.events[SUNRISE] || !conf.events[SUNSET]) {
+    if (!conf.no_gamma && (!conf.events[SUNRISE] || !conf.events[SUNSET])) {
         int fd;
         
         if (conf.lat != 0 && conf.lon != 0) {
@@ -43,6 +45,7 @@ void init_location(void) {
         }
         set_pollfd(fd, LOCATION_IX, location_cb);
         INFO("Location module started.\n");
+        inited = 1;
     }
 }
 
@@ -150,8 +153,7 @@ static void geoclue_check_initial_location(void) {
  * If we are using geoclue, stop client.
  */
 void destroy_location(void) {
-    /* if location module is loaded */
-    if (!conf.events[SUNRISE] || !conf.events[SUNSET]) {
+    if (inited) {
         if (is_geoclue()) {
             geoclue_client_stop();
         } else if (main_p.p[LOCATION_IX].fd > 0) {

--- a/clight/src/log.c
+++ b/clight/src/log.c
@@ -31,7 +31,9 @@ void log_conf(void) {
         fprintf(log_file, "* Nightly screen temp: %d\n", conf.temp[NIGHT]);
         fprintf(log_file, "* Smooth transitions: %d\n", conf.smooth_transition);
         fprintf(log_file, "* Latitude: %.2lf\n", conf.lat);
-        fprintf(log_file, "* Longitude: %.2lf\n\n", conf.lon);
+        fprintf(log_file, "* Longitude: %.2lf\n", conf.lon);
+        fprintf(log_file, "* User setted sunrise: %s\n", conf.events[SUNRISE]);
+        fprintf(log_file, "* User setted sunset: %s\n\n", conf.events[SUNSET]);
     }
 }
 

--- a/clight/src/log.c
+++ b/clight/src/log.c
@@ -29,11 +29,12 @@ void log_conf(void) {
         fprintf(log_file, "* Backlight path: %s\n", conf.screen_path);
         fprintf(log_file, "* Daily screen temp: %d\n", conf.temp[DAY]);
         fprintf(log_file, "* Nightly screen temp: %d\n", conf.temp[NIGHT]);
-        fprintf(log_file, "* Smooth transitions: %d\n", conf.smooth_transition);
+        fprintf(log_file, "* Smooth transitions: %s\n", conf.no_smooth_transition ? "disabled" : "enabled");
         fprintf(log_file, "* Latitude: %.2lf\n", conf.lat);
         fprintf(log_file, "* Longitude: %.2lf\n", conf.lon);
         fprintf(log_file, "* User setted sunrise: %s\n", conf.events[SUNRISE]);
-        fprintf(log_file, "* User setted sunset: %s\n\n", conf.events[SUNSET]);
+        fprintf(log_file, "* User setted sunset: %s\n", conf.events[SUNSET]);
+        fprintf(log_file, "* Gamma correction: %s\n\n", conf.no_gamma ? "disabled" : "enabled");
     }
 }
 

--- a/clight/src/opts.c
+++ b/clight/src/opts.c
@@ -17,7 +17,6 @@ void init_opts(int argc, char *argv[]) {
     conf.temp[NIGHT] = 4000;
     conf.temp[EVENT] = -1;
     conf.temp[UNKNOWN] = 6500;
-    conf.smooth_transition = 1;
 
     parse_cmd(argc, argv);
 
@@ -64,11 +63,11 @@ static void parse_cmd(int argc, char *const argv[]) {
         {"night_timeout", 0, POPT_ARG_INT, &conf.timeout[NIGHT], 0, "Seconds between each capture during the night. Defaults to 45mins", NULL},
         {"device", 'd', POPT_ARG_STRING, &conf.dev_name, 0, "Path to webcam device. By default, first matching device is used", "/dev/videoX"},
         {"backlight", 'b', POPT_ARG_STRING, &conf.screen_path, 0, "Path to backlight syspath. By default, first matching device is used", "/sys/class/backlight/foo"},
-        {"smooth_transition", 0, POPT_ARG_INT, &conf.smooth_transition, 0, "1 enables/0 disables smooth gamma transition", NULL},
+        {"no-smooth_transition", 0, POPT_ARG_NONE, &conf.no_smooth_transition, 0, "Disable smooth gamma transition", NULL},
         {"day_temp", 0, POPT_ARG_INT, &conf.temp[DAY], 0, "Daily gamma temperature, between 1000 and 10000", NULL},
         {"night_temp", 0, POPT_ARG_INT, &conf.temp[NIGHT], 0, "Nightly gamma temperature, between 1000 and 10000", NULL},
-        {"lat", 0, POPT_ARG_DOUBLE, &conf.lat, 0, "Your desired latitude", "40.9"},
-        {"lon", 0, POPT_ARG_DOUBLE, &conf.lon, 0, "Your desired longitude", "8.60"},
+        {"lat", 0, POPT_ARG_DOUBLE, &conf.lat, 0, "Your desired latitude", NULL},
+        {"lon", 0, POPT_ARG_DOUBLE, &conf.lon, 0, "Your desired longitude", NULL},
         {"sunrise", 0, POPT_ARG_STRING, &conf.events[SUNRISE], 0, "Force sunrise time for gamma correction", "07:00"},
         {"sunset", 0, POPT_ARG_STRING, &conf.events[SUNSET], 0, "Force sunset time for gamma correction", "19:00"},
         {"no-gamma", 0, POPT_ARG_NONE, &conf.no_gamma, 0, "Disable gamma correction tool", NULL},
@@ -77,7 +76,6 @@ static void parse_cmd(int argc, char *const argv[]) {
     };
 
     pc = poptGetContext(NULL, argc, (const char **)argv, po, 0);
-    // process options and handle each val returned
     int rc = poptGetNextOpt(pc);
     // poptGetNextOpt returns -1 when the final argument has been parsed
     // otherwise an error occured

--- a/clight/src/opts.c
+++ b/clight/src/opts.c
@@ -16,7 +16,7 @@ void init_opts(int argc, char *argv[]) {
     conf.temp[DAY] = 6500;
     conf.temp[NIGHT] = 4000;
     conf.temp[EVENT] = -1;
-    conf.temp[UNKNOWN] = -1;
+    conf.temp[UNKNOWN] = 6500;
     conf.smooth_transition = 1;
 
     parse_cmd(argc, argv);
@@ -62,30 +62,22 @@ static void parse_cmd(int argc, char *const argv[]) {
         {"frames", 'f', POPT_ARG_INT, &conf.num_captures, 0, "Frames taken for each capture. Defaults to 5.", "Number of frames to be taken."},
         {"day_timeout", 0, POPT_ARG_INT, &conf.timeout[DAY], 0, "Timeout between captures during the day. Defaults to 10mins.", "Number of seconds between each capture."},
         {"night_timeout", 0, POPT_ARG_INT, &conf.timeout[NIGHT], 0, "Timeout between captures during the night. Defaults to 45mins.", "Number of seconds between each capture."},
-        {"device", 'd', POPT_ARG_STRING, NULL, 1, "Path to webcam device. By default, first matching device is used.", "Webcam device to be used."},
-        {"backlight", 'b', POPT_ARG_STRING, NULL, 2, "Path to backlight syspath. By default, first matching device is used.", "Backlight to be used."},
+        {"device", 'd', POPT_ARG_STRING, &conf.dev_name, 0, "Path to webcam device. By default, first matching device is used.", "Webcam device to be used."},
+        {"backlight", 'b', POPT_ARG_STRING, &conf.screen_path, 0, "Path to backlight syspath. By default, first matching device is used.", "Backlight to be used."},
         {"smooth_transition", 0, POPT_ARG_INT, &conf.smooth_transition, 0, "Whether to enable smooth gamma transition.", "1 enable/0 disable."},
         {"day_temp", 0, POPT_ARG_INT, &conf.temp[DAY], 0, "Daily gamma temperature.", "Between 1000 and 10000."},
         {"night_temp", 0, POPT_ARG_INT, &conf.temp[NIGHT], 0, "Nightly gamma temperature.", "Between 1000 and 10000."},
         {"lat", 0, POPT_ARG_DOUBLE, &conf.lat, 0, "Your current latitude.", NULL},
         {"lon", 0, POPT_ARG_DOUBLE, &conf.lon, 0, "Your current longitude.", NULL},
+        {"sunrise", 0, POPT_ARG_STRING, &conf.events[SUNRISE], 0, "Force a sunrise time when switch gamma temp.", "Sunrise time, eg: 07:00."},
+        {"sunset", 0, POPT_ARG_STRING, &conf.events[SUNSET], 0, "Force a sunset time when switch gamma temp.", "Sunset time, eg: 19:00."},
         POPT_AUTOHELP
         {NULL}
     };
 
     pc = poptGetContext(NULL, argc, (const char **)argv, po, 0);
     // process options and handle each val returned
-    int rc;
-    while ((rc = poptGetNextOpt(pc)) >= 0) {
-        switch (rc) {
-            case 1:
-                strncpy(conf.dev_name, poptGetOptArg(pc), PATH_MAX);
-                break;
-            case 2:
-                strncpy(conf.screen_path, poptGetOptArg(pc), PATH_MAX);
-                break;
-        }
-    }
+    int rc = poptGetNextOpt(pc);
     // poptGetNextOpt returns -1 when the final argument has been parsed
     // otherwise an error occured
     if (rc != -1) {
@@ -94,4 +86,19 @@ static void parse_cmd(int argc, char *const argv[]) {
         exit(1);
     }
     poptFreeContext(pc);
+}
+
+void destroy_opts(void) {
+    if (conf.events[SUNRISE]) {
+        free(conf.events[SUNRISE]);
+    }
+    if (conf.events[SUNSET]) {
+        free(conf.events[SUNSET]);
+    }
+    if (conf.dev_name) {
+        free(conf.dev_name);
+    }
+    if (conf.screen_path) {
+        free(conf.screen_path);
+    }
 }

--- a/clight/src/opts.c
+++ b/clight/src/opts.c
@@ -71,6 +71,7 @@ static void parse_cmd(int argc, char *const argv[]) {
         {"lon", 0, POPT_ARG_DOUBLE, &conf.lon, 0, "Your current longitude.", NULL},
         {"sunrise", 0, POPT_ARG_STRING, &conf.events[SUNRISE], 0, "Force a sunrise time when switch gamma temp.", "Sunrise time, eg: 07:00."},
         {"sunset", 0, POPT_ARG_STRING, &conf.events[SUNSET], 0, "Force a sunset time when switch gamma temp.", "Sunset time, eg: 19:00."},
+        {"no-gamma", 0, POPT_ARG_NONE, &conf.no_gamma, 0, "Disable gamma correction tool.", NULL},
         POPT_AUTOHELP
         {NULL}
     };

--- a/clight/src/opts.c
+++ b/clight/src/opts.c
@@ -58,20 +58,20 @@ void init_opts(int argc, char *argv[]) {
 static void parse_cmd(int argc, char *const argv[]) {
     poptContext pc;
     struct poptOption po[] = {
-        {"capture", 'c', POPT_ARG_NONE, &conf.single_capture_mode, 0, "Take a fast capture/screen brightness calibration and quit.", NULL},
-        {"frames", 'f', POPT_ARG_INT, &conf.num_captures, 0, "Frames taken for each capture. Defaults to 5.", "Number of frames to be taken."},
-        {"day_timeout", 0, POPT_ARG_INT, &conf.timeout[DAY], 0, "Timeout between captures during the day. Defaults to 10mins.", "Number of seconds between each capture."},
-        {"night_timeout", 0, POPT_ARG_INT, &conf.timeout[NIGHT], 0, "Timeout between captures during the night. Defaults to 45mins.", "Number of seconds between each capture."},
-        {"device", 'd', POPT_ARG_STRING, &conf.dev_name, 0, "Path to webcam device. By default, first matching device is used.", "Webcam device to be used."},
-        {"backlight", 'b', POPT_ARG_STRING, &conf.screen_path, 0, "Path to backlight syspath. By default, first matching device is used.", "Backlight to be used."},
-        {"smooth_transition", 0, POPT_ARG_INT, &conf.smooth_transition, 0, "Whether to enable smooth gamma transition.", "1 enable/0 disable."},
-        {"day_temp", 0, POPT_ARG_INT, &conf.temp[DAY], 0, "Daily gamma temperature.", "Between 1000 and 10000."},
-        {"night_temp", 0, POPT_ARG_INT, &conf.temp[NIGHT], 0, "Nightly gamma temperature.", "Between 1000 and 10000."},
-        {"lat", 0, POPT_ARG_DOUBLE, &conf.lat, 0, "Your current latitude.", NULL},
-        {"lon", 0, POPT_ARG_DOUBLE, &conf.lon, 0, "Your current longitude.", NULL},
-        {"sunrise", 0, POPT_ARG_STRING, &conf.events[SUNRISE], 0, "Force a sunrise time when switch gamma temp.", "Sunrise time, eg: 07:00."},
-        {"sunset", 0, POPT_ARG_STRING, &conf.events[SUNSET], 0, "Force a sunset time when switch gamma temp.", "Sunset time, eg: 19:00."},
-        {"no-gamma", 0, POPT_ARG_NONE, &conf.no_gamma, 0, "Disable gamma correction tool.", NULL},
+        {"capture", 'c', POPT_ARG_NONE, &conf.single_capture_mode, 0, "Take a fast capture/screen brightness calibration and quit", NULL},
+        {"frames", 'f', POPT_ARG_INT, &conf.num_captures, 0, "Frames taken for each capture, BBetween 1 and 20. Defaults to 5", NULL},
+        {"day_timeout", 0, POPT_ARG_INT, &conf.timeout[DAY], 0, "Seconds between each capture during the day. Defaults to 10mins", NULL},
+        {"night_timeout", 0, POPT_ARG_INT, &conf.timeout[NIGHT], 0, "Seconds between each capture during the night. Defaults to 45mins", NULL},
+        {"device", 'd', POPT_ARG_STRING, &conf.dev_name, 0, "Path to webcam device. By default, first matching device is used", "/dev/videoX"},
+        {"backlight", 'b', POPT_ARG_STRING, &conf.screen_path, 0, "Path to backlight syspath. By default, first matching device is used", "/sys/class/backlight/foo"},
+        {"smooth_transition", 0, POPT_ARG_INT, &conf.smooth_transition, 0, "1 enables/0 disables smooth gamma transition", NULL},
+        {"day_temp", 0, POPT_ARG_INT, &conf.temp[DAY], 0, "Daily gamma temperature, between 1000 and 10000", NULL},
+        {"night_temp", 0, POPT_ARG_INT, &conf.temp[NIGHT], 0, "Nightly gamma temperature, between 1000 and 10000", NULL},
+        {"lat", 0, POPT_ARG_DOUBLE, &conf.lat, 0, "Your desired latitude", "40.9"},
+        {"lon", 0, POPT_ARG_DOUBLE, &conf.lon, 0, "Your desired longitude", "8.60"},
+        {"sunrise", 0, POPT_ARG_STRING, &conf.events[SUNRISE], 0, "Force sunrise time for gamma correction", "07:00"},
+        {"sunset", 0, POPT_ARG_STRING, &conf.events[SUNSET], 0, "Force sunset time for gamma correction", "19:00"},
+        {"no-gamma", 0, POPT_ARG_NONE, &conf.no_gamma, 0, "Disable gamma correction tool", NULL},
         POPT_AUTOHELP
         {NULL}
     };

--- a/clight/src/opts.c
+++ b/clight/src/opts.c
@@ -34,7 +34,7 @@ void init_opts(int argc, char *argv[]) {
         conf.timeout[NIGHT] = 45 * 60;
     }
 
-    if (conf.num_captures <= 0) {
+    if (conf.num_captures <= 0 || conf.num_captures > 20) {
         ERROR("Wrong frames value. Resetting default value.\n");
         conf.num_captures = 5;
     }

--- a/clight/src/signal.c
+++ b/clight/src/signal.c
@@ -38,7 +38,7 @@ static void signal_cb(void) {
 }
 
 void destroy_signal(void) {
-    if (main_p.p[SIGNAL_IX].fd != -1) {
+    if (main_p.p[SIGNAL_IX].fd > 0) {
         close(main_p.p[SIGNAL_IX].fd);
     }
     INFO("Signal module destroyed.\n");

--- a/clight/src/signal.c
+++ b/clight/src/signal.c
@@ -4,6 +4,8 @@
 
 static void signal_cb(void);
 
+static int inited;
+
 /**
  * Set signals handler for SIGINT and SIGTERM (using a signalfd)
  */
@@ -18,6 +20,7 @@ void init_signal(void) {
     int fd = signalfd(-1, &mask, 0);
     set_pollfd(fd, SIGNAL_IX, signal_cb);
     INFO("Signal module started.\n");
+    inited = 1;
 }
 
 /*
@@ -38,8 +41,10 @@ static void signal_cb(void) {
 }
 
 void destroy_signal(void) {
-    if (main_p.p[SIGNAL_IX].fd > 0) {
-        close(main_p.p[SIGNAL_IX].fd);
+    if (inited) {
+        if (main_p.p[SIGNAL_IX].fd > 0) {
+            close(main_p.p[SIGNAL_IX].fd);
+        }
+        INFO("Signal module destroyed.\n");
     }
-    INFO("Signal module destroyed.\n");
 }

--- a/clightd/DEBIAN/control
+++ b/clightd/DEBIAN/control
@@ -1,0 +1,8 @@
+Package: clightd
+Version: 0.1
+Section: base
+Priority: optional
+Architecture: amd64
+Depends: libsystemd0, libudev1, libxrandr2, libx11-xcb1, libjpeg62-turbo
+Maintainer: Federico Di Pierro <nierro92@gmail.com>
+Description: Clightd bus interface to set screen brightness and gamma.

--- a/clightd/README.md
+++ b/clightd/README.md
@@ -36,12 +36,16 @@ Uninstall:
 
     $  cppcheck --enable=style --enable=performance --enable=unusedFunction 
     
-## Info
+## Devel info
+Brightness related bus interface methods make all use of libudev to write and read current values (no fopen or other things like that).  
+If no syspath is passed as parameter to method calls, it uses first subsystem matching device that it finds through libudev.  
+Strict error checking tries to enforce no issue of any kind.  
+
 You may ask why did i developed this solution. The answer is quite simple: on linux there is no simple and unified way of changing screen brightness.  
 So, i thought it could be a good idea to develop a bus service that can be used by every other program.
 
 My idea is that anyone can now implement something similar to clight without messing with videodev or libjpeg.  
-A clight bash replacement, using clightd, can be something like (pseudo-code):
+A clight replacement, using clightd, can be something like (pseudo-code):
 
     $ max_br = busctl call org.clight.backlight /org/clight/backlight org.clight.backlight getmaxbrightness s ""
     $ ambient_br = busctl call org.clight.backlight /org/clight/backlight org.clight.backlight captureframe s ""

--- a/clightd/README.md
+++ b/clightd/README.md
@@ -1,30 +1,42 @@
 This is clight's own bus interface.
 
-It currently needs:
+## It currently needs:
 * libsystemd (systemd/sd-bus.h)
 * libudev (libudev.h)
 
-Needed only if built with gamma support:
+### Needed only if built with gamma support:
 * libxrandr (X11/extensions/Xrandr.h)
 * libx11 (X11/Xlib.h)
 
-Neded only if built with frame captures support:
+### Needed only if built with frame captures support:
 * libjpeg-turbo (turbojpeg.h)
 * linux-api-headers (linux/videodev2.h)
 
-Build time switches:
+## Build time switches:
 * DISABLE_FRAME_CAPTURES=1 (to disable frame captures support)
 * DISABLE_GAMMA=1 (to disable gamma support)
 
-Build instructions:
+## Build instructions:
+Build and install:
 
     $ make
     # make install
 
-To uninstall:
+Uninstall:
 
     # make uninstall
+    
+**It is fully valgrind and cppcheck clean.**
 
+### Valgrind is run with:
+    
+    $ alias valgrind='valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all -v'
+    
+### Cppcheck is run with:
+
+    $  cppcheck --enable=style --enable=performance --enable=unusedFunction 
+    
+## Info
 You may ask why did i developed this solution. The answer is quite simple: on linux there is no simple and unified way of changing screen brightness.  
 So, i thought it could be a good idea to develop a bus service that can be used by every other program.
 
@@ -38,7 +50,7 @@ A clight bash replacement, using clightd, can be something like (pseudo-code):
 
 Note that passing an empty string as first parameter will make clightd use first subsystem matching device it finds (through libudev). It should be good to go in most cases.
 
-Bus interface methods:
+## Bus interface methods
 * *getbrightness* -> takes a backlight kernel interface (eg: intel_backlight) or nothing to just use first backlight kernel interface that libudev finds.
 Returns current brightness value (int).
 * *getmaxbrightness* -> takes a backlight kernel interface (as above). Returns max supported brightness value for that interface (int).
@@ -46,12 +58,11 @@ Returns current brightness value (int).
 Note that new brightness value is checked to be between 0 and max_brightness.
 * *getactualbrightness* -> takes a backlight kernel interface. Returns actual brightness for that interface (int).
 
-If built with gamma support:
+### If built with gamma support:
 * *getgamma* -> returns current display temperature (int).
 * *setgamma* -> takes a temperature value (int, between 1000 and 10000) and set display temperature. Returns newly setted display temperature (int).
 
-If built with frame captures support:
+### If built with frame captures support:
 * *captureframe* -> takes a video sysname (eg: video0). Returns average frame brightness, between 0.0 and 1.0 (double).
-
 
 **It does only support jpeg screen captures. So, if your webcam does not support jpeg frame captures, you are out of luck, sorry.**

--- a/clightd/README.md
+++ b/clightd/README.md
@@ -1,7 +1,7 @@
 This is clight's own bus interface.
 
 ## It currently needs:
-* libsystemd (systemd/sd-bus.h)
+* libsystemd >= 221 (systemd/sd-bus.h)
 * libudev (libudev.h)
 
 ### Needed only if built with gamma support:
@@ -25,24 +25,24 @@ Build and install:
 Uninstall:
 
     # make uninstall
-    
-**It is fully valgrind and cppcheck clean.**
+
+**It is fully valgrind and cppcheck clean.**  
 
 ### Valgrind is run with:
-    
+
     $ alias valgrind='valgrind --tool=memcheck --leak-check=full --track-origins=yes --show-leak-kinds=all -v'
-    
+
 ### Cppcheck is run with:
 
-    $  cppcheck --enable=style --enable=performance --enable=unusedFunction 
-    
+    $  cppcheck --enable=style --enable=performance --enable=unusedFunction
+
 ## Devel info
 Brightness related bus interface methods make all use of libudev to write and read current values (no fopen or other things like that).  
 If no syspath is passed as parameter to method calls, it uses first subsystem matching device that it finds through libudev.  
 Strict error checking tries to enforce no issue of any kind.  
 
 You may ask why did i developed this solution. The answer is quite simple: on linux there is no simple and unified way of changing screen brightness.  
-So, i thought it could be a good idea to develop a bus service that can be used by every other program.
+So, i thought it could be a good idea to develop a bus service that can be used by every other program.  
 
 My idea is that anyone can now implement something similar to clight without messing with videodev or libjpeg.  
 A clight replacement, using clightd, can be something like (pseudo-code):

--- a/clightd/README.md
+++ b/clightd/README.md
@@ -48,7 +48,7 @@ My idea is that anyone can now implement something similar to clight without mes
 A clight replacement, using clightd, can be something like (pseudo-code):
 
     $ max_br = busctl call org.clight.backlight /org/clight/backlight org.clight.backlight getmaxbrightness s ""
-    $ ambient_br = busctl call org.clight.backlight /org/clight/backlight org.clight.backlight captureframe s ""
+    $ ambient_br = busctl call org.clight.backlight /org/clight/backlight org.clight.backlight captureframes si "" 5
     $ new_br = ambient_br * max_br
     $ busctl call org.clight.backlight /org/clight/backlight org.clight.backlight setbrightness si "" new_br
 
@@ -67,6 +67,6 @@ Note that new brightness value is checked to be between 0 and max_brightness.
 * *setgamma* -> takes a temperature value (int, between 1000 and 10000) and set display temperature. Returns newly setted display temperature (int).
 
 ### If built with frame captures support:
-* *captureframe* -> takes a video sysname (eg: video0). Returns average frame brightness, between 0.0 and 1.0 (double).
+* *captureframes* -> takes a video sysname (eg: video0) and a number of frames to be captured (int, between 1 and 20). Returns average frames brightness, between 0.0 and 1.0 (double).
 
 **It does only support jpeg screen captures. So, if your webcam does not support jpeg frame captures, you are out of luck, sorry.**

--- a/clightd/Scripts/org.clight.backlight.conf
+++ b/clightd/Scripts/org.clight.backlight.conf
@@ -6,7 +6,7 @@
         <allow own="org.clight.backlight"/>
     </policy>
           
-    <!-- Anyone can send messages to the owner of org.freedesktop.UDisks2 -->
+    <!-- Anyone can send messages -->
     <policy context="default">
         <allow send_destination="org.clight.backlight"/>
     </policy>

--- a/clightd/Scripts/org.clight.backlight.service
+++ b/clightd/Scripts/org.clight.backlight.service
@@ -1,4 +1,4 @@
 [D-BUS Service]
-Name=org.clight.brightness  
-Exec=/usr/lib/clight/clightd
+Name=org.clight.backlight
+Exec=/usr/lib/clightd/clightd
 User=root

--- a/clightd/Scripts/org.clightd.backlight.conf
+++ b/clightd/Scripts/org.clightd.backlight.conf
@@ -3,12 +3,12 @@
   "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
 <busconfig>
     <policy user="root">
-        <allow own="org.clight.backlight"/>
+        <allow own="org.clightd.backlight"/>
     </policy>
           
     <!-- Anyone can send messages -->
     <policy context="default">
-        <allow send_destination="org.clight.backlight"/>
+        <allow send_destination="org.clightd.backlight"/>
     </policy>
 
 </busconfig>

--- a/clightd/Scripts/org.clightd.backlight.policy
+++ b/clightd/Scripts/org.clightd.backlight.policy
@@ -3,7 +3,7 @@
 "http://www.freedesktop.org/software/polkit/policyconfig-1.dtd">
 <policyconfig>
     
-    <action id="org.clight.backlight.setbrightness">
+    <action id="org.clightd.backlight.setbrightness">
         <icon_name>battery</icon_name> 
         <defaults>
             <allow_any>no</allow_any>

--- a/clightd/Scripts/org.clightd.backlight.service
+++ b/clightd/Scripts/org.clightd.backlight.service
@@ -1,4 +1,4 @@
 [D-BUS Service]
-Name=org.clight.backlight
+Name=org.clightd.backlight
 Exec=/usr/lib/clightd/clightd
 User=root

--- a/clightd/TODO.md
+++ b/clightd/TODO.md
@@ -3,3 +3,5 @@ TODO:
 - [ ] add polkit checkAuthorization support. (MID) -> this way only active session can affect screen brightness/gamma (https://wiki.archlinux.org/index.php/Polkit#Actions)
 - [ ] fix gettemp: it returns 6524 for 6500...find a way to deal with this approximation -> max_temp, min_temp and temperature int?
 - [x] move back number_of_frame_captured support to clightd (it is very slow to re-init every resource for every capture.)
+- [x] add debian/ubuntu deb package script
+- [ ] switch to opencv2 to support non-jpeg cameras

--- a/clightd/TODO.md
+++ b/clightd/TODO.md
@@ -2,4 +2,5 @@ TODO:
 
 - [ ] add polkit checkAuthorization support. (MID) -> this way only active session can affect screen brightness/gamma (https://wiki.archlinux.org/index.php/Polkit#Actions)
 - [x] fix getgamma for certain values of temp (eg : < 5950 and others)
-- [ ] fix gettemp: it returns 6524 for 6500...find a way to deal with this approximation 
+- [ ] fix gettemp: it returns 6524 for 6500...find a way to deal with this approximation -> max_temp, min_temp and temperature int? Poi controllare altro... 
+- [x] fix readme (use same layout as clight readme file)

--- a/clightd/TODO.md
+++ b/clightd/TODO.md
@@ -1,6 +1,5 @@
 TODO:
 
 - [ ] add polkit checkAuthorization support. (MID) -> this way only active session can affect screen brightness/gamma (https://wiki.archlinux.org/index.php/Polkit#Actions)
-- [x] fix getgamma for certain values of temp (eg : < 5950 and others)
-- [ ] fix gettemp: it returns 6524 for 6500...find a way to deal with this approximation -> max_temp, min_temp and temperature int? Poi controllare altro... 
-- [x] fix readme (use same layout as clight readme file)
+- [ ] fix gettemp: it returns 6524 for 6500...find a way to deal with this approximation -> max_temp, min_temp and temperature int?
+- [x] move back number_of_frame_captured support to clightd (it is very slow to re-init every resource for every capture.)

--- a/clightd/TODO.md
+++ b/clightd/TODO.md
@@ -2,3 +2,4 @@ TODO:
 
 - [ ] add polkit checkAuthorization support. (MID) -> this way only active session can affect screen brightness/gamma (https://wiki.archlinux.org/index.php/Polkit#Actions)
 - [x] fix getgamma for certain values of temp (eg : < 5950 and others)
+- [ ] fix gettemp: it returns 6524 for 6500...find a way to deal with this approximation 

--- a/clightd/inc/camera.h
+++ b/clightd/inc/camera.h
@@ -12,6 +12,6 @@
 
 #include "commons.h"
 
-double capture_frames(const char *interface, int *err);
+double capture_frames(const char *interface, int num_captures, int *err);
 
 #endif

--- a/clightd/makefile
+++ b/clightd/makefile
@@ -1,11 +1,14 @@
-BINDIR = /usr/lib/clight
+BINDIR = /usr/lib/clightd
 BINNAME = clightd
 BUSCONFDIR = /etc/dbus-1/system.d/
 BUSCONFNAME = org.clight.backlight.conf
 BUSSERVICEDIR = /usr/share/dbus-1/system-services/
 BUSSERVICENAME = org.clight.backlight.service
-EXTRADIR = Script
+EXTRADIR = Scripts
+DEBIANDIR = ./Clightd
+DEBOUTPUTDIR = ../Debian
 RM = rm -f
+RMDIR = rm -rf
 INSTALL = install -p
 INSTALL_PROGRAM = $(INSTALL) -m755
 INSTALL_DATA = $(INSTALL) -m644
@@ -60,15 +63,31 @@ clightd-debug: objects-debug
 clean:
 	@cd $(SRCDIR); $(RM) *.o
 
+deb: all install-deb build-deb clean-deb
+
+install-deb: DESTDIR=$(DEBIANDIR)
+install-deb: install
+
+build-deb:
+	$(info copying debian build script.)
+	@cp -r DEBIAN/ $(DEBIANDIR)
+	@$(INSTALL_DIR) $(DEBOUTPUTDIR)
+	$(info creating debian package.)
+	@dpkg-deb --build $(DEBIANDIR) $(DEBOUTPUTDIR)
+
+clean-deb:
+	$(info cleaning up.)
+	@$(RMDIR) $(DEBIANDIR)
+
 install:
 	$(info installing bin.)
 	@$(INSTALL_DIR) "$(DESTDIR)$(BINDIR)"
 	@$(INSTALL_PROGRAM) $(BINNAME) "$(DESTDIR)$(BINDIR)"
-	
+
 	$(info installing dbus conf file.)
 	@$(INSTALL_DIR) "$(DESTDIR)$(BUSCONFDIR)"
 	@$(INSTALL_DATA) $(EXTRADIR)/$(BUSCONFNAME) "$(DESTDIR)$(BUSCONFDIR)"
-	
+
 	$(info installing dbus service file.)
 	@$(INSTALL_DIR) "$(DESTDIR)$(BUSSERVICEDIR)"
 	@$(INSTALL_DATA) $(EXTRADIR)/$(BUSSERVICENAME) "$(DESTDIR)$(BUSSERVICEDIR)"
@@ -76,9 +95,9 @@ install:
 uninstall:
 	$(info uninstalling bin.)
 	@$(RM) "$(DESTDIR)$(BINDIR)/$(BINNAME)"
-	
+
 	$(info uninstalling dbus conf file.)
 	@$(RM) "$(DESTDIR)$(BUSCONFDIR)/$(BUSCONFNAME)"
-	
+
 	$(info uninstalling dbus service file.)
 	@$(RM) "$(DESTDIR)$(BUSSERVICEDIR)/$(BUSSERVICENAME)"

--- a/clightd/makefile
+++ b/clightd/makefile
@@ -1,9 +1,9 @@
 BINDIR = /usr/lib/clightd
 BINNAME = clightd
 BUSCONFDIR = /etc/dbus-1/system.d/
-BUSCONFNAME = org.clight.backlight.conf
+BUSCONFNAME = org.clightd.backlight.conf
 BUSSERVICEDIR = /usr/share/dbus-1/system-services/
-BUSSERVICENAME = org.clight.backlight.service
+BUSSERVICENAME = org.clightd.backlight.service
 EXTRADIR = Scripts
 DEBIANDIR = ./Clightd
 DEBOUTPUTDIR = ../Debian

--- a/clightd/src/camera.c
+++ b/clightd/src/camera.c
@@ -112,6 +112,7 @@ static void init(void) {
     
     if (-1 == xioctl(VIDIOC_S_FMT, &fmt)) {
         perror("Setting Pixel Format");
+        state->quit = 1;
         return;
     }
     

--- a/clightd/src/clightd.c
+++ b/clightd/src/clightd.c
@@ -316,7 +316,7 @@ static void get_first_matching_device(struct udev_device **dev, const char *subs
 static void get_udev_device(const char *backlight_interface, const char *subsystem,
                             sd_bus_error **ret_error, struct udev_device **dev) {
     // if no backlight_interface is specified, try to get first matching device
-    if (!strlen(backlight_interface)) {
+    if (!backlight_interface || !strlen(backlight_interface)) {
         get_first_matching_device(dev, subsystem);
     } else {
         *dev = udev_device_new_from_subsystem_sysname(udev, subsystem, backlight_interface);

--- a/clightd/src/clightd.c
+++ b/clightd/src/clightd.c
@@ -44,8 +44,8 @@ static void get_udev_device(const char *backlight_interface, const char *subsyst
                             sd_bus_error **ret_error, struct udev_device **dev);
 
 
-static const char object_path[] = "/org/clight/backlight";
-static const char bus_interface[] = "org.clight.backlight";
+static const char object_path[] = "/org/clightd/backlight";
+static const char bus_interface[] = "org.clightd.backlight";
 static struct udev *udev;
 /**
  * Bus spec: https://dbus.freedesktop.org/doc/dbus-specification.html

--- a/clightd/src/gamma.c
+++ b/clightd/src/gamma.c
@@ -11,7 +11,7 @@ static double clamp(double x, double max);
 static double get_red(int temp);
 static double get_green(int temp);
 static double get_blue(int temp);
-static double get_temp(const double R, const double B);
+static double get_temp(const unsigned short R, const unsigned short B);
 
 static double clamp(double x, double max) {
     if (x > max) { 
@@ -66,20 +66,19 @@ static double get_blue(int temp) {
 }
 
 /* Thanks to: https://github.com/neilbartlett/color-temperature/blob/master/index.js */
-static double get_temp(const double R, const double B) {
+static double get_temp(const unsigned short R, const unsigned short B) {
     double temperature;
-    double testR,  testB;
     double epsilon=0.4;
-    double minTemperature = 1000;
-    double maxTemperature = 40000;
-    while (maxTemperature - minTemperature > epsilon) {
-        temperature = (maxTemperature + minTemperature) / 2;
-        testR = get_red(temperature);
-        testB = get_blue(temperature);
-        if ((testB / testR) >= (B / R)) {
-            maxTemperature = temperature;
+    double min_temp = 1000;
+    double max_temp = 10000;
+    while (max_temp - min_temp > epsilon) {
+        temperature = (max_temp + min_temp) / 2;
+        unsigned short testR = get_red(temperature);
+        unsigned short testB = get_blue(temperature);
+        if (((double) testB / testR) >= ((double) B / R)) {
+            max_temp = temperature;
         } else {
-            minTemperature = temperature;
+            min_temp = temperature;
         }
     }
     return round(temperature);

--- a/clightd/src/gamma.c
+++ b/clightd/src/gamma.c
@@ -99,11 +99,6 @@ void set_gamma(int temp, int *err) {
     Window root = RootWindow(dpy, screen);
 
     XRRScreenResources *res = XRRGetScreenResourcesCurrent(dpy, root);
-
-    if (temp < 1000 || temp > 10000) {
-        *err = EINVAL;
-        return;
-    }
     
     double red = get_red(temp) / 255;
     double green = get_green(temp) / 255;


### PR DESCRIPTION
Lots of devel commits:
* added support for event "range": an event starts 30mins before and ends 30mins after a sunrise/sunset; during an event, webcam captures are more frequent (every 3 mins).
* add --no-gamma to disable gamma correction tool at runtime
* moved back number_of_captures to be taken into clightd bus interface (way faster than re-init every variable/re-open webcam device for each frame)
* updated opts helper messages
* renamed clight to clighd in bus interface
* fixed a couple of bugs
* Added deb packaging support (make deb)
* smooth_transition options is now a "--no-smooth_transition" flag