### PR TITLE
Pm inhibit

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,9 @@ Location received will be then cached when clight exit. This way, if no internet
 Moreover, you can set a percentage of maximum settable brightness while on battery.
 * You can specify curve points to be used to match ambient brightness to screen backlight from config file. For more info, see [Polynomial fit](https://github.com/FedeDP/Clight#polynomial-fit) section below.
 * It will check if current backlight interface is enabled before changing backlight/dimming screen. It will avoid to do any frame capture at all if interface is disabled. It can happen when you use your laptop connected to an external monitor, with internal monitor switched off; thus changing backlight would be useless.
+* DPMS support: it will set desired dpms timeouts for AC/batt states.
+* Dpms and dimmer can be disabled while on AC, just set dimmer timeout/any dpms timeout for given AC state <= 0.
+* Clight supports org.freedesktop.PowerManagement.Inhibit interface. Thus, when for example watching a youtube video from chromium, dimmer module won't dim your screen.
 * Gracefully auto-disabling unsupported module (eg: GAMMA on non-X environments)
 
 ### Valgrind is run with:

--- a/TODO.md
+++ b/TODO.md
@@ -33,7 +33,7 @@
 - [x] avoid dimming screen if a power management inhibitor is set through logind (eg: while watching a movie). busctl --user call org.freedesktop.PowerManagement.Inhibit /org/freedesktop/PowerManagement org.freedesktop.PowerManagement.Inhibit HasInhibit (HasInhibitChanged signal) -> works on kde and xfce. (gnome seems to be using its own interface...)
 - [x] pause dimmer while inhibition is enabled. Restart dimmer as soon as inhibition is disabled
 - [x] disable dpms while PowerManagement is inhibited too
-- [ ] fix bug with setdpms call on bus ?? -> The name org.clightd.backlight was not provided by any .service files (but it seems working!)
+- [x] fix bug with setdpms call on bus ?? -> The name org.clightd.backlight was not provided by any .service files (but it seems working!)
 - [x] gamma_smooth and dimmer_smooth should be marked as submodules of gamma/dimmer. When a module is started, all of its submodule gets started right away.
 - [x] gamma_smooth and dimmer_smooth should get started disarmed
 - [x] dimmer should get started disarmed if we're in inhibit mode
@@ -47,6 +47,7 @@
 
 ## 1.2
 - [ ] subscribe to "interfaceEnabledChanged" signal from clightd (as soon as it is implemented in clightd) and do a capture as soon as interface became enabled (May be disable both dimmer and brightness while interface is disabled)
+- [ ] rework conf settings: timeouts should be: AC_capture_timeouts = { 600, 2700, 300 } BATT_capture_timeouts = {  } 
 
 ## Later
 - [ ] add weather support -> New struct for timeouts wuld be something like conf.timeout[enum state][enum weather] where enum weather = { UNWKNOWN, SUNNY, RAINY, CLOUDY } and defaults to 0 obviously -> state.weather = 0; ...or just use something like conf.temp[state.time] that cuts up to 50% at 100% cloudiness

--- a/TODO.md
+++ b/TODO.md
@@ -30,10 +30,11 @@
 - [x] add a modules[m].state in module struct and an enum module_states { UNKNOWN, DISABLED, INTIED }
 - [x] if module gets inited, if needed call its various callbacks setter for UPOWER, GEOCLUE(add_mod_callback) (eventually both, use a variadic parameter)
 - [x] add a fake X module required by modules who needs X server running (to avoid check() to call !state.display || !state.xauthority)
-- [ ] avoid dimming screen if a power management inhibitor is set through logind (eg: while watching a movie).
+- [x] avoid dimming screen if a power management inhibitor is set through logind (eg: while watching a movie). busctl --user call org.freedesktop.PowerManagement.Inhibit /org/freedesktop/PowerManagement org.freedesktop.PowerManagement.Inhibit HasInhibit (HasInhibitChanged signal) -> works on kde and xfce. (gnome seems to be using its own interface...)
 
 ## 1.2
 - [ ] subscribe to "interfaceEnabledChanged" signal from clightd (as soon as it is implemented in clightd) and do a capture as soon as interface became enabled (May be disable both dimmer and brightness while interface is disabled)
+- [ ] "pause" modules when they're not needed (eg: dimmer while inhibition is enabled) -> set_timeout(fd, 0, 0) and restart them when needed. Check which module needs this.
 
 ## Later
 - [ ] add weather support -> New struct for timeouts wuld be something like conf.timeout[enum state][enum weather] where enum weather = { UNWKNOWN, SUNNY, RAINY, CLOUDY } and defaults to 0 obviously -> state.weather = 0; ...or just use something like conf.temp[state.time] that cuts up to 50% at 100% cloudiness

--- a/TODO.md
+++ b/TODO.md
@@ -31,10 +31,10 @@
 - [x] if module gets inited, if needed call its various callbacks setter for UPOWER, GEOCLUE(add_mod_callback) (eventually both, use a variadic parameter)
 - [x] add a fake X module required by modules who needs X server running (to avoid check() to call !state.display || !state.xauthority)
 - [x] avoid dimming screen if a power management inhibitor is set through logind (eg: while watching a movie). busctl --user call org.freedesktop.PowerManagement.Inhibit /org/freedesktop/PowerManagement org.freedesktop.PowerManagement.Inhibit HasInhibit (HasInhibitChanged signal) -> works on kde and xfce. (gnome seems to be using its own interface...)
+- [x] pause dimmer while inhibition is enabled. Restart dimmer as soon as inhibition is disabled
 
 ## 1.2
 - [ ] subscribe to "interfaceEnabledChanged" signal from clightd (as soon as it is implemented in clightd) and do a capture as soon as interface became enabled (May be disable both dimmer and brightness while interface is disabled)
-- [ ] "pause" modules when they're not needed (eg: dimmer while inhibition is enabled) -> set_timeout(fd, 0, 0) and restart them when needed. Check which module needs this.
 
 ## Later
 - [ ] add weather support -> New struct for timeouts wuld be something like conf.timeout[enum state][enum weather] where enum weather = { UNWKNOWN, SUNNY, RAINY, CLOUDY } and defaults to 0 obviously -> state.weather = 0; ...or just use something like conf.temp[state.time] that cuts up to 50% at 100% cloudiness

--- a/TODO.md
+++ b/TODO.md
@@ -25,13 +25,25 @@
 - [x] test --no-dpms, --no-dimmer, --no-gamma -> --no-dimmer disables brightness module
 - [x] update to new clightd captureframes interface
 - [x] Use modules[X].disabled = 1 instead of conf.no_gamma, no_dimmer, no-dpms etc etc
-- [x] smarter init_modules() -> avoid in various check() functions call to conf.single_capture_mode. 
+- [x] smarter init_modules() -> avoid in various check() functions call to conf.single_capture_mode.
 - [x] FIXME: dimmer module gets disabled as soon as dimmer-smooth module is disabled as it is only module dependent
 - [x] add a modules[m].state in module struct and an enum module_states { UNKNOWN, DISABLED, INTIED }
 - [x] if module gets inited, if needed call its various callbacks setter for UPOWER, GEOCLUE(add_mod_callback) (eventually both, use a variadic parameter)
 - [x] add a fake X module required by modules who needs X server running (to avoid check() to call !state.display || !state.xauthority)
 - [x] avoid dimming screen if a power management inhibitor is set through logind (eg: while watching a movie). busctl --user call org.freedesktop.PowerManagement.Inhibit /org/freedesktop/PowerManagement org.freedesktop.PowerManagement.Inhibit HasInhibit (HasInhibitChanged signal) -> works on kde and xfce. (gnome seems to be using its own interface...)
 - [x] pause dimmer while inhibition is enabled. Restart dimmer as soon as inhibition is disabled
+- [x] disable dpms while PowerManagement is inhibited too
+- [ ] fix bug with setdpms call on bus ?? -> The name org.clightd.backlight was not provided by any .service files (but it seems working!)
+- [x] gamma_smooth and dimmer_smooth should be marked as submodules of gamma/dimmer. When a module is started, all of its submodule gets started right away.
+- [x] gamma_smooth and dimmer_smooth should get started disarmed
+- [x] dimmer should get started disarmed if we're in inhibit mode
+- [x] dpms/dimmer: pause while on AC/BATT if timeouts are <=0
+- [x] submodule should register themselves in SET_SELF() (eg: submoduleof = { GAMMA } -> set_module_self will set it as a submodule of gamma)
+- [x] call set self for each module automatically
+- [x] fix: all set_$module_self functions now give "unused" warning...
+- [x] userbus submodule of bus
+- [x] move sd_bus *userbus in bus.c and get_user_bus() in bus.c to remove #include "userbus.h" in bus.h
+- [x] it seems like dpms gets autodisabled while watching a video on chromium, so dpms module should not depend on INHIBIT
 
 ## 1.2
 - [ ] subscribe to "interfaceEnabledChanged" signal from clightd (as soon as it is implemented in clightd) and do a capture as soon as interface became enabled (May be disable both dimmer and brightness while interface is disabled)

--- a/inc/brightness.h
+++ b/inc/brightness.h
@@ -1,5 +1,3 @@
-#include "bus.h"
-
 void set_brightness_self(void);
 void get_current_brightness(void);
 void set_backlight_level(int level);

--- a/inc/bus.h
+++ b/inc/bus.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#include <systemd/sd-bus.h>
-#include "timer.h"
-#include "userbus.h"
+#include "modules.h"
 
 struct bus_cb {
     enum modules module;

--- a/inc/bus.h
+++ b/inc/bus.h
@@ -2,6 +2,7 @@
 
 #include <systemd/sd-bus.h>
 #include "timer.h"
+#include "userbus.h"
 
 struct bus_cb {
     enum modules module;
@@ -16,10 +17,12 @@ struct bus_args {
     const char *path;
     const char *interface;
     const char *member;
+    enum bus_type type;
 };
 
 void set_bus_self(void);
-int bus_call(void *userptr, const char *userptr_type, const struct bus_args *args, const char *signature, ...);
+void bus_callback(void);
+int call(void *userptr, const char *userptr_type, const struct bus_args *args, const char *signature, ...);
 int add_match(const struct bus_args *a, sd_bus_slot **slot, sd_bus_message_handler_t cb);
 int set_property(const struct bus_args *a, const char type, const char *value);
 int get_property(const struct bus_args *a, const char *type, void *userptr);

--- a/inc/bus.h
+++ b/inc/bus.h
@@ -2,9 +2,14 @@
 
 #include "modules.h"
 
+struct bus_match_data {
+    int bus_mod_idx;
+    void *ptr;
+};
+
 struct bus_cb {
     enum modules module;
-    void (*cb)(void);
+    void (*cb)(const void *ptr);
 };
 
 /*

--- a/inc/bus.h
+++ b/inc/bus.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "modules.h"
+#include <systemd/sd-bus.h>
 
 struct bus_match_data {
     int bus_mod_idx;
@@ -30,3 +31,4 @@ int add_match(const struct bus_args *a, sd_bus_slot **slot, sd_bus_message_handl
 int set_property(const struct bus_args *a, const char type, const char *value);
 int get_property(const struct bus_args *a, const char *type, void *userptr);
 void add_mod_callback(const struct bus_cb cb);
+sd_bus **get_user_bus(void);

--- a/inc/commons.h
+++ b/inc/commons.h
@@ -13,6 +13,7 @@
 #include <math.h>
 #include <pwd.h>
 #include <setjmp.h>
+#include <systemd/sd-bus.h>
 
 /*
  * Useful macro to check size of global array.

--- a/inc/commons.h
+++ b/inc/commons.h
@@ -92,7 +92,6 @@ struct state {
     enum events next_event;                 // next event index (sunrise/sunset)
     int event_time_range;                   // variable that holds minutes in advance/after an event to enter/leave EVENT state
     enum ac_states ac_state;                // is laptop on battery?
-    enum ac_states old_ac_state;            // was laptop on battery?
     int fast_recapture;                     // fast recapture after huge brightness drop?
     double fit_parameters[SIZE_AC][DEGREE]; // best-fit parameters
     const char *xauthority;                 // xauthority env variable, to be used in gamma calls

--- a/inc/commons.h
+++ b/inc/commons.h
@@ -26,7 +26,7 @@
 #define DEGREE 3                            // number of parameters for polynomial regression
 
 /* List of modules indexes */
-enum modules { BRIGHTNESS, LOCATION, UPOWER, GAMMA, GAMMA_SMOOTH, SIGNAL, BUS, DIMMER, DIMMER_SMOOTH, DPMS, XORG, MODULES_NUM };
+enum modules { BRIGHTNESS, LOCATION, UPOWER, GAMMA, GAMMA_SMOOTH, SIGNAL, BUS, DIMMER, DIMMER_SMOOTH, DPMS, XORG, INHIBIT, USERBUS, MODULES_NUM };
 
 /*
  * List of states clight can be through: 
@@ -51,6 +51,9 @@ enum dpms_states { STANDBY, SUSPEND, OFF, SIZE_DPMS };
 
 /* Module states */
 enum module_states { IDLE, DISABLED, INITED };
+
+/* Bus types */
+enum bus_type { SYSTEM, USER };
 
 /* Struct that holds global config as passed through cmdline args */
 struct config {
@@ -96,6 +99,7 @@ struct state {
     struct brightness br;                   // struct that hold screen backlight info
     int is_dimmed;                          // whether we are currently in dimmed state
     int dimmed_br;                          // backlight level when dimmed
+    int pm_inhibited;                       // whether powermanagement is inhibited
     jmp_buf quit_buf;                       // quit jump called by longjmp
 };
 

--- a/inc/commons.h
+++ b/inc/commons.h
@@ -41,8 +41,8 @@ enum states { DAY, NIGHT, EVENT, SIZE_STATES };
 /* List of events: sunrise and sunset */
 enum events { SUNRISE, SUNSET, SIZE_EVENTS };
 
-/* Whether a inter-module dep is hard (mandatory) or soft dep */
-enum dep_type { HARD, SOFT };
+/* Whether a module A on B dep is hard (mandatory), soft dep or it is its submodule */
+enum dep_type { HARD, SOFT, SUBMODULE };
 
 /* Whether laptop is on battery or connected to ac */
 enum ac_states { ON_AC, ON_BATTERY, SIZE_AC };
@@ -130,6 +130,8 @@ struct module {
     enum modules *dependent_m;            // pointer to every dependent module self
     int num_dependent;                    // number of dependent-on-this-module modules
     enum module_states state;             // state of a module
+    enum modules *submodules;             // List of module submodules
+    int num_submodules;                   // number of submodules
 };
 
 struct state state;

--- a/inc/config.h
+++ b/inc/config.h
@@ -1,4 +1,4 @@
-#include "modules.h"
+#include "../inc/log.h"
 
 enum CONFIG { GLOBAL, LOCAL };
 

--- a/inc/dimmer.h
+++ b/inc/dimmer.h
@@ -1,3 +1,3 @@
-#include "../inc/bus.h"
+#include "bus.h"
 
 void set_dimmer_self(void);

--- a/inc/dimmer.h
+++ b/inc/dimmer.h
@@ -1,3 +1,1 @@
-#include "bus.h"
-
 void set_dimmer_self(void);

--- a/inc/dimmer_smooth.h
+++ b/inc/dimmer_smooth.h
@@ -1,4 +1,2 @@
-#include "bus.h"
-
 void set_dimmer_smooth_self(void);
 void start_smooth_transition(long delay);

--- a/inc/dimmer_smooth.h
+++ b/inc/dimmer_smooth.h
@@ -1,4 +1,4 @@
-#include "../inc/bus.h"
+#include "bus.h"
 
 void set_dimmer_smooth_self(void);
 void start_smooth_transition(long delay);

--- a/inc/gamma_smooth.h
+++ b/inc/gamma_smooth.h
@@ -1,4 +1,4 @@
-#include "../inc/bus.h"
+#include "bus.h"
 
 void set_gamma_smooth_self(void);
 void start_gamma_transition(long delay);

--- a/inc/inhibit.h
+++ b/inc/inhibit.h
@@ -1,0 +1,4 @@
+#include "bus.h"
+
+void set_inhibit_self(void);
+

--- a/inc/inhibit.h
+++ b/inc/inhibit.h
@@ -1,4 +1,2 @@
-#include "bus.h"
-
 void set_inhibit_self(void);
 

--- a/inc/location.h
+++ b/inc/location.h
@@ -1,3 +1,1 @@
-#include "bus.h"
-
 void set_location_self(void);

--- a/inc/modules.h
+++ b/inc/modules.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include "timer.h"
+#include <dlfcn.h>
+#include <glob.h>
 
 #define SET_SELF() \
 do { \
@@ -11,6 +13,26 @@ do { \
     modules[self.idx].destroy = destroy; \
     set_self_deps(&self); \
 } while (0)
+
+/* Useful macro to call each module's "set_$module_self" functions */
+#define SET_MODULES_SELFS() \
+do { \
+    void (*func)(void); \
+    char funcname[40] = {0}; \
+    glob_t results; \
+    glob("src/*.c", 0, NULL, &results); \
+    for (int i = 0; i < results.gl_pathc; i++) { \
+        char *name = strndup(results.gl_pathv[i] + 4, strlen(results.gl_pathv[i]) - 6); \
+        sprintf(funcname, "set_%s_self", name); \
+        free(name); \
+        *(void **)(&func) = dlsym(NULL, funcname); \
+        if (func) { \
+            DEBUG("Function %s found!\n", funcname); \
+            func(); \
+        } \
+    } \
+    globfree(& results); \
+} while(0)
 
 #define INIT_MOD(fd, ...) init_module(fd, self.idx, ##__VA_ARGS__, (void *)0)
 

--- a/inc/modules.h
+++ b/inc/modules.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "log.h"
+#include "timer.h"
 
 #define SET_SELF() \
 do { \

--- a/inc/modules.h
+++ b/inc/modules.h
@@ -18,13 +18,11 @@ do { \
 #define SET_MODULES_SELFS() \
 do { \
     void (*func)(void); \
-    char funcname[40] = {0}; \
+    char funcname[NAME_MAX] = {0}; \
     glob_t results; \
     glob("src/*.c", 0, NULL, &results); \
     for (int i = 0; i < results.gl_pathc; i++) { \
-        char *name = strndup(results.gl_pathv[i] + 4, strlen(results.gl_pathv[i]) - 6); \
-        sprintf(funcname, "set_%s_self", name); \
-        free(name); \
+        snprintf(funcname, NAME_MAX, "set_%.*s_self", (int) strlen(results.gl_pathv[i]) - 6, results.gl_pathv[i] + 4); \
         *(void **)(&func) = dlsym(NULL, funcname); \
         if (func) { \
             DEBUG("Function %s found!\n", funcname); \

--- a/inc/signal.h
+++ b/inc/signal.h
@@ -1,3 +1,1 @@
-#include "modules.h"
-
 void set_signal_self(void);

--- a/inc/timer.h
+++ b/inc/timer.h
@@ -3,7 +3,6 @@
 
 int start_timer(int clockid, int initial_s, int initial_ns);
 void set_timeout(int sec, int nsec, int fd, int flag);
-void disarm_timer(const enum modules mod);
 long get_timeout_sec(int fd);
 // long get_timeout_nsec(int fd);
 void reset_timer(int fd, int old_timer, int new_timer);

--- a/inc/timer.h
+++ b/inc/timer.h
@@ -1,5 +1,5 @@
-#include "modules.h"
 #include <sys/timerfd.h>
+#include "log.h"
 
 int start_timer(int clockid, int initial_s, int initial_ns);
 void set_timeout(int sec, int nsec, int fd, int flag);

--- a/inc/timer.h
+++ b/inc/timer.h
@@ -3,6 +3,7 @@
 
 int start_timer(int clockid, int initial_s, int initial_ns);
 void set_timeout(int sec, int nsec, int fd, int flag);
+void disarm_timer(const enum modules mod);
 long get_timeout_sec(int fd);
 // long get_timeout_nsec(int fd);
 void reset_timer(int fd, int old_timer, int new_timer);

--- a/inc/upower.h
+++ b/inc/upower.h
@@ -1,3 +1,1 @@
-#include "bus.h"
-
 void set_upower_self(void);

--- a/inc/userbus.h
+++ b/inc/userbus.h
@@ -1,4 +1,1 @@
-#include <systemd/sd-bus.h>
-
 void set_userbus_self(void);
-sd_bus *get_user_bus(void);

--- a/inc/userbus.h
+++ b/inc/userbus.h
@@ -1,6 +1,4 @@
-#pragma once
-
-#include "bus.h"
+#include <systemd/sd-bus.h>
 
 void set_userbus_self(void);
 sd_bus *get_user_bus(void);

--- a/inc/userbus.h
+++ b/inc/userbus.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include "bus.h"
+
+void set_userbus_self(void);
+sd_bus *get_user_bus(void);

--- a/inc/xorg.h
+++ b/inc/xorg.h
@@ -1,3 +1,1 @@
-#include "modules.h"
-
 void set_xorg_self(void);

--- a/makefile
+++ b/makefile
@@ -18,7 +18,7 @@ INSTALL_PROGRAM = $(INSTALL) -m755
 INSTALL_DATA = $(INSTALL) -m644
 INSTALL_DIR = $(INSTALL) -d
 SRCDIR = src/
-LIBS = -lm $(shell pkg-config --libs libsystemd popt gsl libconfig)
+LIBS = -lm -ldl $(shell pkg-config --libs libsystemd popt gsl libconfig) -rdynamic
 CFLAGS = $(shell pkg-config --cflags libsystemd popt gsl libconfig) -DCONFDIR=\"$(CONFDIR)\" -D_GNU_SOURCE -std=c99
 
 ifeq (,$(findstring $(MAKECMDGOALS),"clean install uninstall"))
@@ -44,7 +44,7 @@ objects-debug:
 	@cd $(SRCDIR); $(CC) -c *.c -Wall $(CFLAGS) -Wshadow -Wstrict-overflow -Wtype-limits -fno-strict-aliasing -Wformat -Wformat-security -g
 
 clight: objects
-	@cd $(SRCDIR); $(CC) -o ../$(BINNAME) *.o $(LIBS)
+	@cd $(SRCDIR); $(CC) -o ../$(BINNAME) *.o $(LIBS) 
 
 clight-debug: objects-debug
 	@cd $(SRCDIR); $(CC) -o ../$(BINNAME) *.o $(LIBS)

--- a/module.skel
+++ b/module.skel
@@ -19,7 +19,7 @@
  * mandatory functions (using macro SET_SELF())
  */
 
-#include "module.h"
+#include "modules.h"
 
 static void init(void);
 static int check(void);

--- a/module.skel
+++ b/module.skel
@@ -43,6 +43,11 @@ static struct self_t self = {
  * Macro to bind module's self_t struct 
  * to global modules[] var, 
  * and setting correct dep tree
+ * This function should be named "set_$module_self",
+ * and module's filename should be $module.c,
+ * eg: set_brightness_self placed in brightness.c.
+ * As all set_$module_self functions are called through dlsym,
+ * by SET_MODULES_SELFS() macro in modules.h.
  */
 void set_module_self(void) {
     SET_SELF();

--- a/src/brightness.c
+++ b/src/brightness.c
@@ -14,7 +14,7 @@ static double capture_frames_brightness(void);
 static double compute_average(double *intensity);
 static void polynomialfit(enum ac_states state);
 static double clamp(double value, double max, double min);
-static void upower_callback(void);
+static void upower_callback(const void *ptr);
 
 static struct dependency dependencies[] = { {HARD, BUS}, {SOFT, GAMMA}, {SOFT, UPOWER} };
 static struct self_t self = {
@@ -215,9 +215,10 @@ static double clamp(double value, double max, double min) {
     return value;
 }
 
-static void upower_callback(void) {
+static void upower_callback(const void *ptr) {
+    int old_ac_state = *(int *)ptr;
     /* Force check that we received an ac_state changed event for real */
-    if (!state.fast_recapture && state.old_ac_state != state.ac_state) {
+    if (!state.fast_recapture && old_ac_state != state.ac_state) {
         /* 
          * do a capture right now as we have 2 different curves for 
          * different AC_STATES, so let's properly honor new curve

--- a/src/brightness.c
+++ b/src/brightness.c
@@ -1,5 +1,4 @@
 #include "../inc/brightness.h"
-#include "../inc/upower.h"
 #include <gsl/gsl_multifit.h>
 #include <gsl/gsl_statistics_double.h>
 
@@ -115,18 +114,18 @@ static void do_capture(void) {
 int is_interface_enabled(void) {
     int enabled;
     struct bus_args args = {"org.clightd.backlight", "/org/clightd/backlight", "org.clightd.backlight", "isbacklightinterfaceenabled"};
-    bus_call(&enabled, "i", &args, "s", conf.screen_path);
+    call(&enabled, "i", &args, "s", conf.screen_path);
     return enabled;
 }
 
 static void get_max_brightness(void) {
     struct bus_args args = {"org.clightd.backlight", "/org/clightd/backlight", "org.clightd.backlight", "getmaxbrightness"};
-    bus_call(&state.br.max, "i", &args, "s", conf.screen_path);
+    call(&state.br.max, "i", &args, "s", conf.screen_path);
 }
 
 void get_current_brightness(void) {
     struct bus_args args = {"org.clightd.backlight", "/org/clightd/backlight", "org.clightd.backlight", "getbrightness"};
-    bus_call(&state.br.old, "i", &args, "s", conf.screen_path);
+    call(&state.br.old, "i", &args, "s", conf.screen_path);
 }
 
 static void set_brightness(const double perc) {
@@ -145,14 +144,14 @@ static void set_brightness(const double perc) {
 
 void set_backlight_level(int level) {
     struct bus_args args = {"org.clightd.backlight", "/org/clightd/backlight", "org.clightd.backlight", "setbrightness"};
-    bus_call(&state.br.current, "i", &args, "si", conf.screen_path, level);
+    call(&state.br.current, "i", &args, "si", conf.screen_path, level);
     INFO("New brightness value: %d\n", state.br.current);
 }
 
 static double capture_frames_brightness(void) {
     struct bus_args args = {"org.clightd.backlight", "/org/clightd/backlight", "org.clightd.backlight", "captureframes"};
     double intensity[conf.num_captures];
-    bus_call(intensity, "ad", &args, "si", conf.dev_name, conf.num_captures);
+    call(intensity, "ad", &args, "si", conf.dev_name, conf.num_captures);
     
     return compute_average(intensity);
 }

--- a/src/brightness.c
+++ b/src/brightness.c
@@ -1,4 +1,5 @@
 #include "../inc/brightness.h"
+#include "../inc/bus.h"
 #include <gsl/gsl_multifit.h>
 #include <gsl/gsl_statistics_double.h>
 

--- a/src/brightness.c
+++ b/src/brightness.c
@@ -26,6 +26,7 @@ static struct self_t self = {
     .enabled_single_capture = 1
 };
 
+// cppcheck-suppress unusedFunction
 void set_brightness_self(void) {
     SET_SELF();
 }
@@ -115,7 +116,7 @@ static void do_capture(void) {
 int is_interface_enabled(void) {
     int enabled;
     struct bus_args args = {"org.clightd.backlight", "/org/clightd/backlight", "org.clightd.backlight", "isbacklightinterfaceenabled"};
-    call(&enabled, "i", &args, "s", conf.screen_path);
+    call(&enabled, "b", &args, "s", conf.screen_path);
     return enabled;
 }
 

--- a/src/bus.c
+++ b/src/bus.c
@@ -1,4 +1,5 @@
 #include "../inc/bus.h"
+#include "../inc/userbus.h"
 
 static void init(void);
 static int check(void);

--- a/src/bus.c
+++ b/src/bus.c
@@ -5,7 +5,7 @@ static void init(void);
 static int check(void);
 static void destroy(void);
 static void callback(void);
-static void run_callbacks(const enum modules mod, const void *userptr);
+static void run_callbacks(const enum modules mod, const void *payload);
 static void free_bus_structs(sd_bus_error *err, sd_bus_message *m, sd_bus_message *reply);
 static int check_err(int r, sd_bus_error *err);
 
@@ -250,10 +250,10 @@ void add_mod_callback(const struct bus_cb cb) {
     }
 }
 
-static void run_callbacks(const enum modules mod, const void *userptr) {
+static void run_callbacks(const enum modules mod, const void *payload) {
     for (int i = 0; i < _cb.num_callbacks; i++) {
         if (_cb.callbacks[i].module == mod) {
-            _cb.callbacks[i].cb(userptr);
+            _cb.callbacks[i].cb(payload);
         }
     }
 }

--- a/src/clight.c
+++ b/src/clight.c
@@ -38,19 +38,9 @@
 #include "../inc/userbus.h"
 
 static void init(int argc, char *argv[]);
-static void set_modules_selfs(void);
 static void init_all_modules(void);
 static void destroy(void);
 static void main_poll(void);
-
-/*
- * pointers to init modules functions;
- */
-static void (*const set_selfs[])(void) = {
-    set_brightness_self, set_location_self, set_upower_self, set_gamma_self, 
-    set_gamma_smooth_self, set_signal_self, set_bus_self, set_dimmer_self, 
-    set_dimmer_smooth_self, set_dpms_self, set_xorg_self, set_inhibit_self, set_userbus_self
-};
 
 int main(int argc, char *argv[]) {
     state.quit = setjmp(state.quit_buf);
@@ -72,17 +62,8 @@ static void init(int argc, char *argv[]) {
     gain_lck();
     open_log();
     log_conf();
-    set_modules_selfs();
+    SET_MODULES_SELFS();
     init_all_modules();
-}
-
-/* 
- * Set each module self struct 
- */
-static void set_modules_selfs(void) {
-    for (int i = 0; i < MODULES_NUM; i++) {
-        set_selfs[i]();
-    }
 }
 
 /* 

--- a/src/clight.c
+++ b/src/clight.c
@@ -34,6 +34,8 @@
 #include "../inc/dimmer.h"
 #include "../inc/dimmer_smooth.h"
 #include "../inc/xorg.h"
+#include "../inc/inhibit.h"
+#include "../inc/userbus.h"
 
 static void init(int argc, char *argv[]);
 static void set_modules_selfs(void);
@@ -45,8 +47,9 @@ static void main_poll(void);
  * pointers to init modules functions;
  */
 static void (*const set_selfs[])(void) = {
-    set_brightness_self, set_location_self, set_upower_self, set_gamma_self, set_gamma_smooth_self,
-    set_signal_self, set_bus_self, set_dimmer_self, set_dimmer_smooth_self, set_dpms_self, set_xorg_self
+    set_brightness_self, set_location_self, set_upower_self, set_gamma_self, 
+    set_gamma_smooth_self, set_signal_self, set_bus_self, set_dimmer_self, 
+    set_dimmer_smooth_self, set_dpms_self, set_xorg_self, set_inhibit_self, set_userbus_self
 };
 
 int main(int argc, char *argv[]) {

--- a/src/dimmer.c
+++ b/src/dimmer.c
@@ -1,6 +1,7 @@
 #include "../inc/dimmer.h"
 #include "../inc/brightness.h"
 #include "../inc/dimmer_smooth.h"
+#include "../inc/bus.h"
 #include <sys/inotify.h>
 
 #define BUF_LEN (sizeof(struct inotify_event) + NAME_MAX + 1)

--- a/src/dimmer_smooth.c
+++ b/src/dimmer_smooth.c
@@ -11,7 +11,7 @@ static void callback(void);
 static void dim_backlight(void);
 static void restore_backlight(void);
 
-static struct dependency dependencies[] = { {HARD, DIMMER}, {HARD, BRIGHTNESS}, {HARD, BUS}, {HARD, XORG} };
+static struct dependency dependencies[] = { {SUBMODULE, DIMMER}, {HARD, BRIGHTNESS}, {HARD, BUS}, {HARD, XORG} };
 static struct self_t self = {
     .name = "DimmerSmooth",
     .idx = DIMMER_SMOOTH,
@@ -19,6 +19,7 @@ static struct self_t self = {
     .deps =  dependencies
 };
 
+// cppcheck-suppress unusedFunction
 void set_dimmer_smooth_self(void) {
     SET_SELF();
 }
@@ -29,7 +30,6 @@ static void init(void) {
     INIT_MOD(fd);
 }
 
-/* Check we're on X, dimmer is enabled and smooth transitioning are enabled */
 static int check(void) {
     return 0;
 }

--- a/src/dimmer_smooth.c
+++ b/src/dimmer_smooth.c
@@ -1,5 +1,6 @@
 #include "../inc/dimmer_smooth.h"
 #include "../inc/brightness.h"
+#include "../inc/bus.h"
 
 #define DIMMER_SMOOTH_TIMEOUT 30 * 1000 * 1000 // 30ms
 

--- a/src/dpms.c
+++ b/src/dpms.c
@@ -44,7 +44,7 @@ static void destroy(void) {
 
 static void set_dpms(void) {
     struct bus_args args_get = {"org.clightd.backlight", "/org/clightd/backlight", "org.clightd.backlight", "setdpms_timeouts"};
-    bus_call(NULL, NULL, &args_get, "ssiii", state.display, state.xauthority, 
+    call(NULL, NULL, &args_get, "ssiii", state.display, state.xauthority, 
              conf.dpms_timeouts[state.ac_state][STANDBY], conf.dpms_timeouts[state.ac_state][SUSPEND], conf.dpms_timeouts[state.ac_state][OFF]);
 }
 

--- a/src/dpms.c
+++ b/src/dpms.c
@@ -63,6 +63,7 @@ static void set_dpms_timeouts(void) {
         call(NULL, NULL, &args_get, "ssiii", state.display, state.xauthority, 
              conf.dpms_timeouts[state.ac_state][STANDBY], conf.dpms_timeouts[state.ac_state][SUSPEND], conf.dpms_timeouts[state.ac_state][OFF]);
     } else {
+        DEBUG("Disabling DPMS as a timeout <= 0 has been found.\n");
         set_dpms(DPMS_DISABLED);
     }
 }

--- a/src/dpms.c
+++ b/src/dpms.c
@@ -2,11 +2,14 @@
 #include "../inc/bus.h"
 #include "../inc/upower.h"
 
+#define DPMS_DISABLED -1
+
 static void init(void);
 static int check(void);
 static void callback(void);
 static void destroy(void);
-static void set_dpms(void);
+static void set_dpms_timeouts(void);
+static void set_dpms(int dpms_state);
 static void upower_callback(const void *ptr);
 
 static struct dependency dependencies[] = { {SOFT, UPOWER}, {HARD, BUS}, {HARD, XORG} };
@@ -17,15 +20,16 @@ static struct self_t self = {
     .deps =  dependencies
 };
 
+// cppcheck-suppress unusedFunction
 void set_dpms_self(void) {
     SET_SELF();
 }
 
-
 static void init(void) {
     struct bus_cb upower_cb = { UPOWER, upower_callback };
     
-    set_dpms();
+    /* pass a non-void ptr to avoid logging in inhibit_callback */
+    set_dpms_timeouts();
     INIT_MOD(DONT_POLL, &upower_cb);
 }
 
@@ -42,16 +46,36 @@ static void destroy(void) {
     /* Skeleton function */
 }
 
-static void set_dpms(void) {
-    struct bus_args args_get = {"org.clightd.backlight", "/org/clightd/backlight", "org.clightd.backlight", "setdpms_timeouts"};
-    call(NULL, NULL, &args_get, "ssiii", state.display, state.xauthority, 
+/* 
+ * Set correct timeouts or disable dpms 
+ * if any timeout for current AC state is <= 0.
+ */
+static void set_dpms_timeouts(void) {
+    int need_disable = 0;
+    for (int i = 0; i < SIZE_DPMS && !need_disable; i++) {
+        if (conf.dpms_timeouts[state.ac_state][i] <= 0) {
+            need_disable = 1;
+        }
+    }
+    
+    if (!need_disable) {
+        struct bus_args args_get = {"org.clightd.backlight", "/org/clightd/backlight", "org.clightd.backlight", "setdpms_timeouts"};
+        call(NULL, NULL, &args_get, "ssiii", state.display, state.xauthority, 
              conf.dpms_timeouts[state.ac_state][STANDBY], conf.dpms_timeouts[state.ac_state][SUSPEND], conf.dpms_timeouts[state.ac_state][OFF]);
+    } else {
+        set_dpms(DPMS_DISABLED);
+    }
+}
+
+static void set_dpms(int dpms_state) {
+    struct bus_args args_get = {"org.clightd.backlight", "/org/clightd/backlight", "org.clightd.backlight", "setdpms"};
+    call(NULL, NULL, &args_get, "ssi", state.display, state.xauthority, dpms_state);
 }
 
 static void upower_callback(const void *ptr) {
     int old_ac_state = *(int *)ptr;
     /* Force check that we received an ac_state changed event for real */
     if (old_ac_state != state.ac_state) {
-        set_dpms();
+        set_dpms_timeouts();
     }
 }

--- a/src/dpms.c
+++ b/src/dpms.c
@@ -7,7 +7,7 @@ static int check(void);
 static void callback(void);
 static void destroy(void);
 static void set_dpms(void);
-static void upower_callback(void);
+static void upower_callback(const void *ptr);
 
 static struct dependency dependencies[] = { {SOFT, UPOWER}, {HARD, BUS}, {HARD, XORG} };
 static struct self_t self = {
@@ -48,9 +48,10 @@ static void set_dpms(void) {
              conf.dpms_timeouts[state.ac_state][STANDBY], conf.dpms_timeouts[state.ac_state][SUSPEND], conf.dpms_timeouts[state.ac_state][OFF]);
 }
 
-static void upower_callback(void) {
+static void upower_callback(const void *ptr) {
+    int old_ac_state = *(int *)ptr;
     /* Force check that we received an ac_state changed event for real */
-    if (state.old_ac_state != state.ac_state) {
+    if (old_ac_state != state.ac_state) {
         set_dpms();
     }
 }

--- a/src/gamma.c
+++ b/src/gamma.c
@@ -19,7 +19,7 @@ static int calculate_sunset(const float lat, const float lng, time_t *tt, int to
 static void get_gamma_events(time_t *now, const float lat, const float lon, int day);
 static void check_next_event(time_t *now);
 static void check_state(time_t *now);
-static void location_callback(void);
+static void location_callback(const void *ptr);
 
 static struct dependency dependencies[] = { {HARD, BUS}, {HARD, LOCATION}, {HARD, XORG} };
 static struct self_t self = {
@@ -314,7 +314,7 @@ static void check_state(time_t *now) {
     }
 }
 
-static void location_callback(void) {
+static void location_callback(__attribute__((unused)) const void *ptr) {
     /* Updated GAMMA module sunrise/sunset for new location */
     state.events[SUNSET] = 0; // to force get_gamma_events to recheck sunrise and sunset for today
     set_timeout(0, 1, main_p[self.idx].fd, 0);

--- a/src/gamma.c
+++ b/src/gamma.c
@@ -29,6 +29,7 @@ static struct self_t self = {
     .deps =  dependencies
 };
 
+// cppcheck-suppress unusedFunction
 void set_gamma_self(void) {
     SET_SELF();
 }

--- a/src/gamma_smooth.c
+++ b/src/gamma_smooth.c
@@ -7,7 +7,7 @@ static int check(void);
 static void destroy(void);
 static void callback(void);
 
-static struct dependency dependencies[] = { {HARD, GAMMA}, {HARD, BUS}, {HARD, XORG} };
+static struct dependency dependencies[] = { {SUBMODULE, GAMMA}, {HARD, BUS}, {HARD, XORG} };
 static struct self_t self = {
     .name = "GammaSmooth",
     .idx = GAMMA_SMOOTH,
@@ -15,21 +15,17 @@ static struct self_t self = {
     .deps =  dependencies
 };
 
+// cppcheck-suppress unusedFunction
 void set_gamma_smooth_self(void) {
     SET_SELF();
 }
 
 static void init(void) {
-    /* 
-     * gamma smooth must smooth transitionins
-     * as soon as it is started
-     * to set correct gamma for current time. 1ns timeout
-     */
-    int fd = start_timer(CLOCK_MONOTONIC, 0, 1);
+    /* Gamma smooth should start disarmed */
+    int fd = start_timer(CLOCK_MONOTONIC, 0, 0);
     INIT_MOD(fd);
 }
 
-/* Check we're on X, dimmer is enabled and smooth transitioning are enabled */
 static int check(void) {
     return 0;
 }

--- a/src/gamma_smooth.c
+++ b/src/gamma_smooth.c
@@ -66,7 +66,7 @@ int set_temp(int temp) {
     if (old_temp == 0) {
         struct bus_args args_get = {"org.clightd.backlight", "/org/clightd/backlight", "org.clightd.backlight", "getgamma"};
         
-        bus_call(&old_temp, "i", &args_get, "ss", state.display, state.xauthority);
+        call(&old_temp, "i", &args_get, "ss", state.display, state.xauthority);
     }
     
     if (old_temp != temp) {
@@ -78,9 +78,9 @@ int set_temp(int temp) {
             } else {
                 old_temp = old_temp + step > temp ? temp : old_temp + step;
             }
-            bus_call(&new_temp, "i", &args_set, "ssi", state.display, state.xauthority, old_temp);
+            call(&new_temp, "i", &args_set, "ssi", state.display, state.xauthority, old_temp);
         } else {
-            bus_call(&new_temp, "i", &args_set, "ssi", state.display, state.xauthority, temp);
+            call(&new_temp, "i", &args_set, "ssi", state.display, state.xauthority, temp);
         }
         if (new_temp == temp) {
             // reset old_temp for next call

--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -59,7 +59,8 @@ static int inhibit_init(void) {
  */
 static int on_inhibit_change(__attribute__((unused)) sd_bus_message *m, void *userdata, __attribute__((unused)) sd_bus_error *ret_error) {
     if (userdata) {
-        *(int *)userdata = self.idx;
+        struct bus_match_data *data = (struct bus_match_data *) userdata;
+        data->bus_mod_idx = self.idx;
     }
     
     struct bus_args args = {"org.freedesktop.PowerManagement.Inhibit", "/org/freedesktop/PowerManagement/Inhibit", "org.freedesktop.PowerManagement.Inhibit", "HasInhibit", USER};

--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -1,4 +1,5 @@
 #include "../inc/inhibit.h"
+#include "../inc/bus.h"
 
 static void init(void);
 static int check(void);

--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -17,6 +17,7 @@ static struct self_t self = {
     .deps =  dependencies
 };
 
+// cppcheck-suppress unusedFunction
 void set_inhibit_self(void) {
     SET_SELF();
 }

--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -1,0 +1,72 @@
+#include "../inc/inhibit.h"
+
+static void init(void);
+static int check(void);
+static void callback(void);
+static void destroy(void);
+static int inhibit_init(void);
+static int on_inhibit_change(sd_bus_message *m, void *userdata, sd_bus_error *ret_error);
+
+static sd_bus_slot *slot;
+static struct dependency dependencies[] = { {HARD, USERBUS}, {HARD, XORG} };
+static struct self_t self = {
+    .name = "Inhibit",
+    .idx = INHIBIT,
+    .num_deps = SIZE(dependencies),
+    .deps =  dependencies
+};
+
+void set_inhibit_self(void) {
+    SET_SELF();
+}
+
+static void init(void) {
+    int r = inhibit_init();
+    /* In case of errors, upower_init returns -1 -> disable inhibit. */
+    INIT_MOD(r == 0 ? DONT_POLL : DONT_POLL_W_ERR);
+}
+
+static int check(void) {
+    return 0; /* Skeleton function needed for modules interface */
+}
+
+static void callback(void) {
+    // Skeleton interface
+}
+
+static void destroy(void) {
+    /* Destroy this match slot */
+    if (slot) {
+        sd_bus_slot_unref(slot);
+    }
+}
+
+/* It needs userbus */
+static int inhibit_init(void) {
+    struct bus_args args = {"org.freedesktop.PowerManagement", "/org/freedesktop/PowerManagement/Inhibit", "org.freedesktop.PowerManagement.Inhibit", "HasInhibitChanged", USER};
+    int r = add_match(&args, &slot, on_inhibit_change);
+    if (r < 0) {
+        WARN("PowerManagement inhibition appears to be unsupported.\n");
+        return -1;   // disable this module
+    }
+    /* check initial inhibit state */
+    return on_inhibit_change(NULL, NULL, NULL);
+}
+
+/* 
+ * Callback on inhibit state changed: recheck new HasInhibit value
+ */
+static int on_inhibit_change(__attribute__((unused)) sd_bus_message *m, void *userdata, __attribute__((unused)) sd_bus_error *ret_error) {
+    if (userdata) {
+        *(int *)userdata = self.idx;
+    }
+    
+    struct bus_args args = {"org.freedesktop.PowerManagement.Inhibit", "/org/freedesktop/PowerManagement/Inhibit", "org.freedesktop.PowerManagement.Inhibit", "HasInhibit", USER};
+    call(&state.pm_inhibited, "b", &args, "");
+    
+    if (userdata) {
+        INFO("PowerManagement inhibition %s.\n", state.pm_inhibited ? "enabled" : "disabled");
+    }
+    return 0;
+}
+

--- a/src/location.c
+++ b/src/location.c
@@ -60,7 +60,7 @@ static void callback(void) {
         load_cache_location();
     } else {
         /* Disarm timerfd as we received a location before it triggered */
-        set_timeout(0, 0, main_p[self.idx].fd, 0);
+        disarm_timer(self.idx);
     }
     /* disable this poll_cb */
     modules[self.idx].poll_cb = NULL;

--- a/src/location.c
+++ b/src/location.c
@@ -1,4 +1,5 @@
 #include "../inc/location.h"
+#include "../inc/bus.h"
 
 static void init(void);
 static int check(void);

--- a/src/location.c
+++ b/src/location.c
@@ -138,7 +138,7 @@ static int check(void) {
  */
 static int geoclue_get_client(void) {
     struct bus_args args = {"org.freedesktop.GeoClue2", "/org/freedesktop/GeoClue2/Manager", "org.freedesktop.GeoClue2.Manager", "GetClient"};
-    return bus_call(client, "o", &args, "");
+    return call(client, "o", &args, "");
 }
 
 /*
@@ -153,7 +153,7 @@ static int geoclue_hook_update(void) {
  * On new location callback: retrieve new_location object,
  * then retrieve latitude and longitude from that object and store them in our conf struct.
  */
-static int on_geoclue_new_location(sd_bus_message *m, __attribute__((unused)) void *userdata, __attribute__((unused)) sd_bus_error *ret_error) {
+static int on_geoclue_new_location(sd_bus_message *m, void *userdata, __attribute__((unused)) sd_bus_error *ret_error) {
     if (userdata) {
         *(int *)userdata = self.idx;
     }
@@ -181,7 +181,7 @@ static int geoclue_client_start(void) {
 
     set_property(&id_args, 's', "clight");
     set_property(&thres_args, 'u', "50000"); // 50kms
-    return bus_call(NULL, "", &call_args, "");
+    return call(NULL, "", &call_args, "");
 }
 
 /*
@@ -189,7 +189,7 @@ static int geoclue_client_start(void) {
  */
 static void geoclue_client_stop(void) {
     struct bus_args args = {"org.freedesktop.GeoClue2", client, "org.freedesktop.GeoClue2.Client", "Stop"};
-    bus_call(NULL, "", &args, "");
+    call(NULL, "", &args, "");
 }
 
 static void cache_location(void) {

--- a/src/location.c
+++ b/src/location.c
@@ -60,7 +60,7 @@ static void callback(void) {
         load_cache_location();
     } else {
         /* Disarm timerfd as we received a location before it triggered */
-        disarm_timer(self.idx);
+        set_timeout(0, 0, main_p[self.idx].fd, 0);
     }
     /* disable this poll_cb */
     modules[self.idx].poll_cb = NULL;
@@ -156,7 +156,8 @@ static int geoclue_hook_update(void) {
  */
 static int on_geoclue_new_location(sd_bus_message *m, void *userdata, __attribute__((unused)) sd_bus_error *ret_error) {
     if (userdata) {
-        *(int *)userdata = self.idx;
+        struct bus_match_data *data = (struct bus_match_data *) userdata;
+        data->bus_mod_idx = self.idx;
     }
     
     const char *new_location, *old_location;

--- a/src/location.c
+++ b/src/location.c
@@ -25,6 +25,7 @@ static struct self_t self = {
     .deps =  dependencies
 };
 
+// cppcheck-suppress unusedFunction
 void set_location_self(void) {
     SET_SELF();
 }

--- a/src/modules.c
+++ b/src/modules.c
@@ -225,6 +225,7 @@ void destroy_modules(void) {
     for (int i = started_modules - 1; i >= 0; i--) {
         destroy_module(sorted_modules[i]);
     }
+    free(sorted_modules);
 }
 
 /*

--- a/src/modules.c
+++ b/src/modules.c
@@ -1,6 +1,7 @@
 #include "../inc/modules.h"
 #include "../inc/bus.h"
 
+static void init_submodules(const enum modules module);
 static void started_cb(enum modules module);
 static void destroy_module(const enum modules module);
 static void disable_module(const enum modules module);
@@ -82,10 +83,21 @@ void init_module(int fd, enum modules module, ...) {
             started_cb(module);
         }
         
+        init_submodules(module);
+        
     } else {
         /* module should be disabled */
         WARN("Error while loading %s module.\n", modules[module].self->name);
         disable_module(module); // disable this module and all of dependent module
+    }
+}
+
+static void init_submodules(const enum modules module) {
+    for (int i = 0; i < modules[module].num_submodules; i++) {
+        const enum modules m = modules[module].submodules[i];
+        DEBUG("%s module being started as submodule of %s...\n", modules[m].self->name, modules[module].self->name);
+        modules[m].self->satisfied_deps++;
+        init_modules(m);
     }
 }
 
@@ -109,6 +121,19 @@ void set_self_deps(struct self_t *self) {
             break;
         }
         modules[m].dependent_m[modules[m].num_dependent - 1] = self->idx;
+        
+        /* 
+         * If dep type is SUBMODULE, store self->idx inside modules[m].submodules.
+         * Submodules will be started as soon as their parent module is started
+         */
+        if (self->deps[i].type == SUBMODULE) {
+            modules[m].submodules = realloc(modules[m].submodules, (++modules[m].num_submodules) * sizeof(enum modules));
+            if (!modules[m].submodules) {
+                ERROR("%s\n", strerror(errno));
+                break;
+            }
+            modules[m].submodules[modules[m].num_submodules - 1] = self->idx;
+        }
     }
 }
 
@@ -236,6 +261,12 @@ static void destroy_module(const enum modules module) {
         free(modules[module].dependent_m);
         modules[module].dependent_m = NULL;
         modules[module].num_dependent = 0;
+    }
+
+    if (modules[module].num_submodules) {
+        free(modules[module].submodules);
+        modules[module].submodules = NULL;
+        modules[module].num_submodules = 0;
     }
     
     if (is_inited(module)) {

--- a/src/opts.c
+++ b/src/opts.c
@@ -192,14 +192,6 @@ static void check_conf(void) {
         WARN("Wrong dimmer backlight percentage value. Resetting default value.\n");
         conf.dimmer_pct = 20;
     }
-    if (conf.dimmer_timeout[ON_AC] <= 0) {
-        WARN("Wrong dimmer timeout on AC value. Resetting default value.\n");
-        conf.dimmer_timeout[ON_AC] = 300;
-    }
-    if (conf.dimmer_timeout[ON_BATTERY] <= 0) {
-        WARN("Wrong dimmer timeout on BATT value. Resetting default value.\n");
-        conf.dimmer_timeout[ON_BATTERY] = 45;
-    }
     
     int i, reg_points_ac_needed = 0, reg_points_batt_needed = 0;
     /* Check regression points values */
@@ -225,29 +217,4 @@ static void check_conf(void) {
                (double[]){ 0.0, 0.15, 0.23, 0.36, 0.52, 0.59, 0.65, 0.71, 0.75, 0.78, 0.80 }, 
                SIZE_POINTS * sizeof(double));
     }
-    
-    /* Check dpms timeout values */
-    int dpms_timeout_ac_needed = 0, dpms_timeout_batt_needed = 0;
-    for (i = 0; i < SIZE_DPMS && !dpms_timeout_ac_needed && !dpms_timeout_batt_needed; i++) {
-        if (conf.dpms_timeouts[ON_AC][i] <= 0) {
-            dpms_timeout_ac_needed = 1;
-        }
-        if (conf.dpms_timeouts[ON_BATTERY][i] <= 0) {
-            dpms_timeout_batt_needed = 1;
-        }
-        
-    }
-    if (dpms_timeout_ac_needed) {
-        WARN("Wrong on ac dpms timeouts. Resetting default values.\n");
-        memcpy(conf.dpms_timeouts[ON_AC], 
-               (int[]){ 900, 1200, 1800 }, 
-               SIZE_DPMS * sizeof(int));
-    }
-    if (dpms_timeout_batt_needed) {
-        WARN("Wrong on batt dpms timeouts. Resetting default values.\n");
-        memcpy(conf.dpms_timeouts[ON_BATTERY], 
-               (int[]){ 300, 420, 600 }, 
-               SIZE_DPMS * sizeof(int));
-    }
-    
 }

--- a/src/signal.c
+++ b/src/signal.c
@@ -15,6 +15,7 @@ static struct self_t self = {
     .enabled_single_capture = 1
 };
 
+// cppcheck-suppress unusedFunction
 void set_signal_self(void) {
     SET_SELF();
 }

--- a/src/signal.c
+++ b/src/signal.c
@@ -1,6 +1,7 @@
 #include <sys/signalfd.h>
 #include <signal.h>
 #include "../inc/signal.h"
+#include "../inc/modules.h"
 
 static void init(void);
 static int check(void);

--- a/src/timer.c
+++ b/src/timer.c
@@ -38,11 +38,6 @@ void set_timeout(int sec, int nsec, int fd, int flag) {
     }
 }
 
-/* Disarm timerfd */
-void disarm_timer(const enum modules mod) {
-    set_timeout(0, 0, main_p[mod].fd, 0);
-}
-
 long get_timeout_sec(int fd) {
     return get_timeout(fd, offsetof(struct timespec, tv_sec));
 }

--- a/src/timer.c
+++ b/src/timer.c
@@ -38,6 +38,11 @@ void set_timeout(int sec, int nsec, int fd, int flag) {
     }
 }
 
+/* Disarm timerfd */
+void disarm_timer(const enum modules mod) {
+    set_timeout(0, 0, main_p[mod].fd, 0);
+}
+
 long get_timeout_sec(int fd) {
     return get_timeout(fd, offsetof(struct timespec, tv_sec));
 }

--- a/src/upower.c
+++ b/src/upower.c
@@ -54,7 +54,7 @@ static int upower_init(void) {
 /* 
  * Callback on upower changes: recheck on_battery boolean value
  */
-static int on_upower_change(__attribute__((unused)) sd_bus_message *m, __attribute__((unused)) void *userdata, __attribute__((unused)) sd_bus_error *ret_error) {
+static int on_upower_change(__attribute__((unused)) sd_bus_message *m, void *userdata, __attribute__((unused)) sd_bus_error *ret_error) {
     if (userdata) {
         *(int *)userdata = self.idx;
     }

--- a/src/upower.c
+++ b/src/upower.c
@@ -1,4 +1,5 @@
 #include "../inc/upower.h"
+#include "../inc/bus.h"
 
 static void init(void);
 static int check(void);

--- a/src/upower.c
+++ b/src/upower.c
@@ -17,6 +17,7 @@ static struct self_t self = {
     .deps =  dependencies
 };
 
+// cppcheck-suppress unusedFunction
 void set_upower_self(void) {
     SET_SELF();
 }

--- a/src/userbus.c
+++ b/src/userbus.c
@@ -6,8 +6,7 @@ static int check(void);
 static void destroy(void);
 static void callback(void);
 
-static sd_bus *userbus;
-static struct dependency dependencies[] = { {HARD, BUS} };
+static struct dependency dependencies[] = { {SUBMODULE, BUS} };
 static struct self_t self = {
     .name = "UserBus",
     .idx = USERBUS,
@@ -15,6 +14,7 @@ static struct self_t self = {
     .deps =  dependencies
 };
 
+// cppcheck-suppress unusedFunction
 void set_userbus_self(void) {
     SET_SELF();
 }
@@ -23,12 +23,13 @@ void set_userbus_self(void) {
  * Open our bus and start lisetining on its fd
  */
 static void init(void) {
-    int r = sd_bus_default_user(&userbus);
+    sd_bus **userbus = get_user_bus();
+    int r = sd_bus_default_user(userbus);
     if (r < 0) {
         ERROR("Failed to connect to user bus: %s\n", strerror(-r));
     }
     // let main poll listen on bus events
-    int bus_fd = sd_bus_get_fd(userbus);
+    int bus_fd = sd_bus_get_fd(*userbus);
     INIT_MOD(bus_fd);
 }
 
@@ -40,8 +41,9 @@ static int check(void) {
  * Close bus
  */
 static void destroy(void) {
-    if (userbus) {
-        userbus = sd_bus_flush_close_unref(userbus);
+    sd_bus **userbus = get_user_bus();
+    if (*userbus) {
+        *userbus = sd_bus_flush_close_unref(*userbus);
     }
 }
 
@@ -50,8 +52,4 @@ static void destroy(void) {
  */
 static void callback(void) {
     bus_callback();
-}
-
-sd_bus *get_user_bus(void) {
-    return userbus;
 }

--- a/src/userbus.c
+++ b/src/userbus.c
@@ -1,0 +1,56 @@
+#include "../inc/userbus.h"
+
+static void init(void);
+static int check(void);
+static void destroy(void);
+static void callback(void);
+
+static sd_bus *userbus;
+static struct dependency dependencies[] = { {HARD, BUS} };
+static struct self_t self = {
+    .name = "UserBus",
+    .idx = USERBUS,
+    .num_deps = SIZE(dependencies),
+    .deps =  dependencies
+};
+
+void set_userbus_self(void) {
+    SET_SELF();
+}
+
+/*
+ * Open our bus and start lisetining on its fd
+ */
+static void init(void) {
+    int r = sd_bus_default_user(&userbus);
+    if (r < 0) {
+        ERROR("Failed to connect to user bus: %s\n", strerror(-r));
+    }
+    // let main poll listen on bus events
+    int bus_fd = sd_bus_get_fd(userbus);
+    INIT_MOD(bus_fd);
+}
+
+static int check(void) {
+    return 0; /* Skeleton function needed for modules interface */
+}
+
+/*
+ * Close bus
+ */
+static void destroy(void) {
+    if (userbus) {
+        userbus = sd_bus_flush_close_unref(userbus);
+    }
+}
+
+/*
+ * Callback for bus events
+ */
+static void callback(void) {
+    bus_callback();
+}
+
+sd_bus *get_user_bus(void) {
+    return userbus;
+}

--- a/src/userbus.c
+++ b/src/userbus.c
@@ -1,4 +1,5 @@
 #include "../inc/userbus.h"
+#include "../inc/bus.h"
 
 static void init(void);
 static int check(void);

--- a/src/xorg.c
+++ b/src/xorg.c
@@ -1,4 +1,5 @@
 #include "../inc/xorg.h"
+#include "../inc/modules.h"
 
 static void init(void);
 static int check(void);

--- a/src/xorg.c
+++ b/src/xorg.c
@@ -12,6 +12,7 @@ static struct self_t self = {
     .standalone = 1
 };
 
+// cppcheck-suppress unusedFunction
 void set_xorg_self(void) {
     SET_SELF();
 }


### PR DESCRIPTION
Added a module that adds a match on  org.freedesktop.PowerManagement.Inhibit.HasInhibitChanged bus signal.
Softwares should inhibit powermanagement functions while eg: watching a video. For example, chromium does this as soon as it starts playing audio /video.
So, while user is watching a video, do not bother him with screen dimming.
This work needed a new module (userbus) that is only a new connection to user session bus; main bus interface is still bus module though.