### PR TITLE
Weather module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ arch:
         - popt
         - libconfig
         - gsl
+        - curl
+        - jansson
     script:
         - "echo $CC"
         - make debug

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ arch:
         - popt
         - libconfig
         - gsl
-        - curl
-        - jansson
     script:
         - "echo $CC"
         - make debug

--- a/Arch/PKGBUILD
+++ b/Arch/PKGBUILD
@@ -4,7 +4,7 @@ pkgname=clight-git
 _gitname=Clight
 pkgver=r78.daf725b
 pkgrel=1
-pkgdesc="A C daemon that turns your webcam into a light sensor. It can also change display gamma temperature."
+pkgdesc="A C daemon that turns your webcam into a light sensor. It can also change display gamma temperature, dim your screen and set your dpms."
 arch=('i686' 'x86_64')
 url="https://github.com/FedeDP/${_gitname}"
 license=('GPL')
@@ -12,7 +12,8 @@ backup=(etc/default/clight.conf)
 depends=('systemd' 'popt' 'libconfig' 'gsl' 'clightd-git')
 makedepends=('git')
 optdepends=('geoclue2: to retrieve user location through geoclue2.'
-            'upower: to save energy by increasing timeouts between captures while on battery.')
+            'upower: to save energy by increasing timeouts between captures while on battery.'
+            'networkmanager: to manage connection state changes.')
 source=("git://github.com/FedeDP/${_gitname}.git")
 install=clight.install
 sha256sums=("SKIP")

--- a/DEBIAN/control
+++ b/DEBIAN/control
@@ -4,6 +4,6 @@ Section: base
 Priority: optional
 Architecture: amd64
 Depends: libpopt0, libsystemd0 (>= 221), libconfig9, libgsl2, clightd (>= 1.4)
-Suggests: geoclue-2.0, upower
+Suggests: geoclue-2.0, upower, network-manager
 Maintainer: Federico Di Pierro <nierro92@gmail.com>
-Description: Clightd bus interface to set screen brightness and gamma temperature.
+Description: A C daemon that turns your webcam into a light sensor. It can also change display gamma temperature, dim your screen and set your dpms.

--- a/Extra/clight.conf
+++ b/Extra/clight.conf
@@ -18,7 +18,7 @@
 # dimmer_timeouts = [ 300, 45 ];
 
 ## Weather timeouts on AC/on BATT.
-## Defaults to 1 hrs / 3 hr
+## Defaults to 1 hr / 3 hrs
 # weather_timeouts = [ 3600, 10800 ];
 
 ## Timeouts for dpms on AC

--- a/Extra/clight.conf
+++ b/Extra/clight.conf
@@ -59,6 +59,9 @@
 ## Uncomment to disable dimmer tool
 # no_dimmer = 1;
 
+## Uncomment to disable weather support
+# no_weather = 1;
+
 ####################
 # BACKLIGHT CURVES #
 ####################

--- a/Extra/clight.conf
+++ b/Extra/clight.conf
@@ -17,6 +17,10 @@
 ## in the corresponding AC state.
 # dimmer_timeouts = [ 300, 45 ];
 
+## Weather timeouts on AC/on BATT.
+## Defaults to 6 hrs for both
+# weather_timeouts = [ 21600, 21600 ];
+
 ## Timeouts for dpms on AC
 ## Set any of these to <= 0 to disable dpms on AC
 # ac_dpms_timeouts = [ 900, 1200, 1800 ];
@@ -98,6 +102,10 @@
 
 ## Change dimmer backlight level, in percentage
 # dimmer_pct = 20;
+
+## OpenWeatherMap apikey to be used for weather support: 
+## it will reduce timeouts between captures depending on cloudiness on your location. 
+# weather_apikey = "";
 
 ## Verbose mode, useful in case of bugs:
 ## run clight in verbose mode,

--- a/Extra/clight.conf
+++ b/Extra/clight.conf
@@ -18,8 +18,8 @@
 # dimmer_timeouts = [ 300, 45 ];
 
 ## Weather timeouts on AC/on BATT.
-## Defaults to 6 hrs for both
-# weather_timeouts = [ 21600, 21600 ];
+## Defaults to 1 hrs / 3 hr
+# weather_timeouts = [ 3600, 10800 ];
 
 ## Timeouts for dpms on AC
 ## Set any of these to <= 0 to disable dpms on AC

--- a/Extra/systemd/clight.service
+++ b/Extra/systemd/clight.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=C daemon to adjust screen brightness to match ambient brightness, as computed capturing frames from webcam
-Wants=geoclue.service upower.service clightd.service
-After=display-manager.service clightd.service geoclue.service upower.service
+Wants=geoclue.service upower.service clightd.service NetworkManager.service
+After=display-manager.service clightd.service geoclue.service upower.service NetworkManager.service
 
 [Service]
 Type=simple

--- a/README.md
+++ b/README.md
@@ -67,10 +67,12 @@ Location received will be then cached when clight exit. This way, if no internet
 * UPower support, to set longer timeouts between captures while on battery, in order to save some energy.
 Moreover, you can set a percentage of maximum settable brightness while on battery.
 * You can specify curve points to be used to match ambient brightness to screen backlight from config file. For more info, see [Polynomial fit](https://github.com/FedeDP/Clight#polynomial-fit) section below.
-* It will check if current backlight interface is enabled before changing backlight/dimming screen. It will avoid to do any frame capture at all if interface is disabled. It can happen when you use your laptop connected to an external monitor, with internal monitor switched off; thus changing backlight would be useless.
+* It will check if current backlight interface is enabled before changing backlight/dimming screen. It will avoid doing any frame capture at all if interface is disabled. It can happen when you use your laptop connected to an external monitor, with internal monitor switched off; thus changing backlight would be useless.
 * DPMS support: it will set desired dpms timeouts for AC/batt states.
 * Dpms and dimmer can be disabled while on AC, just set dimmer timeout/any dpms timeout for given AC state <= 0.
 * Clight supports org.freedesktop.PowerManagement.Inhibit interface. Thus, when for example watching a youtube video from chromium, dimmer module won't dim your screen.
+* Weather support: if an OpenWeatherMap apikey is provided through conf file or cmdline option, clight will adjust timeouts between captures given current cloudiness. Function that adjusts timeouts is quite simple: if cloudiness > 50 -> current timeout is shorten of (cloudiness - 50) / 100. This way, at 51 timeout will be 99% of original timeout. At 100 it will be 50%.
+* NetworkManager StateChanged signal is supported, thus modules can react to connection state changes (only used by weather for now).
 * Gracefully auto-disabling unsupported module (eg: GAMMA on non-X environments)
 
 ### Valgrind is run with:

--- a/TODO.md
+++ b/TODO.md
@@ -10,7 +10,7 @@
 - [ ] fix: gamma/gamma smooth start twice only with weather module enabled.
 
 ### Log file rework
-- [ ] Do not print Latitude = 0.0 Longitude = 0.0 in log file if no user position is setted
+- [x] Do not print Latitude = 0.0 Longitude = 0.0 in log file if no user position is setted
 - [ ] Rework conf log (like conf file -> ## Module, ## Generic, ## Timeouts ecc ecc)
 - [x] Fix log: is_started_disabled instead of is_disabled?
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,7 +8,7 @@
 - [x] conf.weather_timeout[ON_AC/ON_BATT] -> timeout between weather refresh
 - [x] weather should call reset_timer on BRIGHTNESS when updating cloudiness informations (but reset_timer on BRIGHTNESS should call get_weather_aware_timeout() even when called by GAMMA/other modules)
 - [x] fix: gamma/gamma smooth start twice only with weather module enabled.
-- [ ] Update readme
+- [x] Update readme
 - [x] FIXME: network with continuous disconnections can lead to lots of owm weather api calls (and battery/network usage too). Find a proper way to deal with this.
 - [x] rework num_dependent -> use array of MODULES_NUM with value enum dep_type
 - [ ] Double check any bug with new dependent_m

--- a/TODO.md
+++ b/TODO.md
@@ -11,6 +11,7 @@
 - [ ] Update readme
 - [x] FIXME: network with continuous disconnections can lead to lots of owm weather api calls (and battery/network usage too). Find a proper way to deal with this.
 - [x] rework num_dependent -> use array of MODULES_NUM with value enum dep_type
+- [ ] Double check any bug with new dependent_m
 
 ### Log file rework
 - [x] Do not print Latitude = 0.0 Longitude = 0.0 in log file if no user position is setted

--- a/TODO.md
+++ b/TODO.md
@@ -7,11 +7,11 @@
 - [x] brightness should depend on weather (soft)
 - [x] conf.weather_timeout[ON_AC/ON_BATT] -> timeout between weather refresh
 - [ ] weather should call reset_timer on BRIGHTNESS when updating cloudiness informations (but reset_timer on BRIGHTNESS should call get_weather_aware_timeout() even when called by GAMMA/other modules)
-- [ ] fix: gamma/gamma smooth start twice only with weather module enabled.
+- [x] fix: gamma/gamma smooth start twice only with weather module enabled.
 
 ### Log file rework
 - [x] Do not print Latitude = 0.0 Longitude = 0.0 in log file if no user position is setted
-- [ ] Rework conf log (like conf file -> ## Module, ## Generic, ## Timeouts ecc ecc)
+- [x] Rework conf log (like conf file -> ## Module, ## Generic, ## Timeouts ecc ecc)
 - [x] Fix log: is_started_disabled instead of is_disabled?
 
 ## Later/Ideas

--- a/TODO.md
+++ b/TODO.md
@@ -6,7 +6,7 @@
 - [ ] weather should depend on network module
 - [x] brightness should depend on weather (soft)
 - [x] conf.weather_timeout[ON_AC/ON_BATT] -> timeout between weather refresh
-- [ ] weather should call reset_timer on BRIGHTNESS when updating cloudiness informations (but reset_timer on BRIGHTNESS should call get_weather_aware_timeout() even when called by GAMMA/other modules)
+- [x] weather should call reset_timer on BRIGHTNESS when updating cloudiness informations (but reset_timer on BRIGHTNESS should call get_weather_aware_timeout() even when called by GAMMA/other modules)
 - [x] fix: gamma/gamma smooth start twice only with weather module enabled.
 
 ### Log file rework

--- a/TODO.md
+++ b/TODO.md
@@ -2,12 +2,14 @@
 ### Weather
 - [x] add weather support -> New struct for timeouts wuld be something like conf.timeout[enum state][enum weather] where enum weather = { UNWKNOWN, SUNNY, RAINY, CLOUDY } and defaults to 0 obviously -> state.weather = 0; ...or just use something like conf.temp[state.time] that cuts up to 50% at 100% cloudiness. Weather support to use conf.apikey and each user has to set his apikey there
 - [x] make it optional at build time (libjansson and libcurl too...or use socket and strstr?)
-- [ ] add a network module that listens on networkmanager connection events and starts weather as soon as a connection is available
-- [ ] weather should depend on network module
+- [x] add a network module that listens on networkmanager connection events and starts weather as soon as a connection is available
+- [x] weather should depend on network module
 - [x] brightness should depend on weather (soft)
 - [x] conf.weather_timeout[ON_AC/ON_BATT] -> timeout between weather refresh
 - [x] weather should call reset_timer on BRIGHTNESS when updating cloudiness informations (but reset_timer on BRIGHTNESS should call get_weather_aware_timeout() even when called by GAMMA/other modules)
 - [x] fix: gamma/gamma smooth start twice only with weather module enabled.
+- [ ] Update readme
+- [x] FIXME: network with continuous disconnections can lead to lots of owm weather api calls (and battery/network usage too). Find a proper way to deal with this.
 
 ### Log file rework
 - [x] Do not print Latitude = 0.0 Longitude = 0.0 in log file if no user position is setted

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,5 @@
 ## 1.4
+### Weather
 - [x] add weather support -> New struct for timeouts wuld be something like conf.timeout[enum state][enum weather] where enum weather = { UNWKNOWN, SUNNY, RAINY, CLOUDY } and defaults to 0 obviously -> state.weather = 0; ...or just use something like conf.temp[state.time] that cuts up to 50% at 100% cloudiness. Weather support to use conf.apikey and each user has to set his apikey there
 - [ ] make it optional at build time (libjansson and libcurl too...or use socket and strstr?)
 - [ ] add a network module that listens on networkmanager connection events and starts weather as soon as a connection is available
@@ -11,6 +12,10 @@ Next gamma alarm due to: Sat Sep  2 19:30:00 2017
 Gamma temp was already 6500
 Gamma temp was already 6500
 
+### Log file rework
+- [ ] Do not print Latitude = 0.0 Longitude = 0.0 in log file if no user position is setted
+- [ ] Rework conf log (like conf file -> ## Module, ## Generic, ## Timeouts ecc ecc)
+- [x] Fix log: is_started_disabled instead of is_disabled?
 
 ## Later/Ideas
 - [ ] subscribe to "interfaceEnabledChanged" signal from clightd (as soon as it is implemented in clightd) and do a capture as soon as interface became enabled (May be disable both dimmer and brightness while interface is disabled)

--- a/TODO.md
+++ b/TODO.md
@@ -1,16 +1,13 @@
 ## 1.4
 ### Weather
 - [x] add weather support -> New struct for timeouts wuld be something like conf.timeout[enum state][enum weather] where enum weather = { UNWKNOWN, SUNNY, RAINY, CLOUDY } and defaults to 0 obviously -> state.weather = 0; ...or just use something like conf.temp[state.time] that cuts up to 50% at 100% cloudiness. Weather support to use conf.apikey and each user has to set his apikey there
-- [ ] make it optional at build time (libjansson and libcurl too...or use socket and strstr?)
+- [x] make it optional at build time (libjansson and libcurl too...or use socket and strstr?)
 - [ ] add a network module that listens on networkmanager connection events and starts weather as soon as a connection is available
 - [ ] weather should depend on network module
 - [x] brightness should depend on weather (soft)
 - [x] conf.weather_timeout[ON_AC/ON_BATT] -> timeout between weather refresh
+- [ ] weather should call reset_timer on BRIGHTNESS when updating cloudiness informations (but reset_timer on BRIGHTNESS should call get_weather_aware_timeout() even when called by GAMMA/other modules)
 - [ ] fix: gamma/gamma smooth start twice only with weather module enabled.
-Next gamma alarm due to: Sat Sep  2 19:30:00 2017
-Next gamma alarm due to: Sat Sep  2 19:30:00 2017
-Gamma temp was already 6500
-Gamma temp was already 6500
 
 ### Log file rework
 - [ ] Do not print Latitude = 0.0 Longitude = 0.0 in log file if no user position is setted

--- a/TODO.md
+++ b/TODO.md
@@ -1,4 +1,16 @@
+## 1.4
+- [x] add weather support -> New struct for timeouts wuld be something like conf.timeout[enum state][enum weather] where enum weather = { UNWKNOWN, SUNNY, RAINY, CLOUDY } and defaults to 0 obviously -> state.weather = 0; ...or just use something like conf.temp[state.time] that cuts up to 50% at 100% cloudiness. Weather support to use conf.apikey and each user has to set his apikey there
+- [ ] make it optional at build time (libjansson and libcurl too...or use socket and strstr?)
+- [ ] add a network module that listens on networkmanager connection events and starts weather as soon as a connection is available
+- [ ] weather should depend on network module
+- [x] brightness should depend on weather (soft)
+- [x] conf.weather_timeout[ON_AC/ON_BATT] -> timeout between weather refresh
+- [ ] fix: gamma/gamma smooth start twice only with weather module enabled.
+Next gamma alarm due to: Sat Sep  2 19:30:00 2017
+Next gamma alarm due to: Sat Sep  2 19:30:00 2017
+Gamma temp was already 6500
+Gamma temp was already 6500
+
+
 ## Later/Ideas
-- [ ] add weather support -> New struct for timeouts wuld be something like conf.timeout[enum state][enum weather] where enum weather = { UNWKNOWN, SUNNY, RAINY, CLOUDY } and defaults to 0 obviously -> state.weather = 0; ...or just use something like conf.temp[state.time] that cuts up to 50% at 100% cloudiness
-- [ ] add a CRITICAL_ON_BATT level to customize even more various timeouts/actions
 - [ ] subscribe to "interfaceEnabledChanged" signal from clightd (as soon as it is implemented in clightd) and do a capture as soon as interface became enabled (May be disable both dimmer and brightness while interface is disabled)

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@
 - [x] fix: gamma/gamma smooth start twice only with weather module enabled.
 - [ ] Update readme
 - [x] FIXME: network with continuous disconnections can lead to lots of owm weather api calls (and battery/network usage too). Find a proper way to deal with this.
+- [x] rework num_dependent -> use array of MODULES_NUM with value enum dep_type
 
 ### Log file rework
 - [x] Do not print Latitude = 0.0 Longitude = 0.0 in log file if no user position is setted

--- a/inc/commons.h
+++ b/inc/commons.h
@@ -27,7 +27,7 @@
 #define DEGREE 3                            // number of parameters for polynomial regression
 
 /* List of modules indexes */
-enum modules { BRIGHTNESS, LOCATION, UPOWER, GAMMA, GAMMA_SMOOTH, SIGNAL, BUS, DIMMER, DIMMER_SMOOTH, DPMS, XORG, INHIBIT, USERBUS, MODULES_NUM };
+enum modules { BRIGHTNESS, LOCATION, UPOWER, GAMMA, GAMMA_SMOOTH, SIGNAL, BUS, DIMMER, DIMMER_SMOOTH, DPMS, XORG, INHIBIT, USERBUS, WEATHER, MODULES_NUM };
 
 /*
  * List of states clight can be through: 
@@ -76,6 +76,8 @@ struct config {
     int dimmer_pct;                         // pct of max brightness to be used while dimming
     int dpms_timeouts[SIZE_AC][SIZE_DPMS];  // dpms timeouts
     int verbose;                            // whether we're in verbose mode
+    char weather_apikey[32 + 1];            // apikey for openweathermap
+    int weather_timeout[SIZE_AC];          // timeouts for weather update
 };
 
 /*
@@ -103,6 +105,7 @@ struct state {
     int is_dimmed;                          // whether we are currently in dimmed state
     int dimmed_br;                          // backlight level when dimmed
     int pm_inhibited;                       // whether powermanagement is inhibited
+    int cloudiness;                         // weather cloudiness for user location
     jmp_buf quit_buf;                       // quit jump called by longjmp
 };
 

--- a/inc/commons.h
+++ b/inc/commons.h
@@ -27,7 +27,7 @@
 #define DEGREE 3                            // number of parameters for polynomial regression
 
 /* List of modules indexes */
-enum modules { BRIGHTNESS, LOCATION, UPOWER, GAMMA, GAMMA_SMOOTH, SIGNAL, BUS, DIMMER, DIMMER_SMOOTH, DPMS, XORG, INHIBIT, USERBUS, WEATHER, MODULES_NUM };
+enum modules { BRIGHTNESS, LOCATION, UPOWER, GAMMA, GAMMA_SMOOTH, SIGNAL, BUS, DIMMER, DIMMER_SMOOTH, DPMS, XORG, INHIBIT, USERBUS, WEATHER, NETWORK, MODULES_NUM };
 
 /*
  * List of states clight can be through: 
@@ -58,6 +58,10 @@ enum bus_type { SYSTEM, USER };
 
 /* Quit values */
 enum quit_values { NORM_QUIT = 1, ERR_QUIT };
+
+enum NMState {  NM_STATE_UNKNOWN = 0, NM_STATE_ASLEEP = 10, NM_STATE_DISCONNECTED = 20, 
+                NM_STATE_DISCONNECTING = 30, NM_STATE_CONNECTING = 40, NM_STATE_CONNECTED_LOCAL = 50, 
+                NM_STATE_CONNECTED_SITE = 60, NM_STATE_CONNECTED_GLOBAL = 70 };
 
 /* Struct that holds global config as passed through cmdline args */
 struct config {
@@ -106,6 +110,7 @@ struct state {
     int dimmed_br;                          // backlight level when dimmed
     int pm_inhibited;                       // whether powermanagement is inhibited
     int cloudiness;                         // weather cloudiness for user location
+    enum NMState nmstate;                           // NetworkManager own states
     jmp_buf quit_buf;                       // quit jump called by longjmp
 };
 

--- a/inc/commons.h
+++ b/inc/commons.h
@@ -42,7 +42,7 @@ enum states { DAY, NIGHT, EVENT, SIZE_STATES };
 enum events { SUNRISE, SUNSET, SIZE_EVENTS };
 
 /* Whether a module A on B dep is hard (mandatory), soft dep or it is its submodule */
-enum dep_type { HARD, SOFT, SUBMODULE };
+enum dep_type { NO_DEP, HARD, SOFT, SUBMODULE };
 
 /* Whether laptop is on battery or connected to ac */
 enum ac_states { ON_AC, ON_BATTERY, SIZE_AC };
@@ -138,7 +138,7 @@ struct module {
     void (*destroy)(void);                // module destroy function
     void (*poll_cb)(void);                // module poll callback
     struct self_t *self;                  // pointer to self module informations
-    struct dependency *dependent_m;       // pointer to every dependent module self
+    enum dep_type dependent_m[MODULES_NUM];// pointer to every dependent module self
     int num_dependent;                    // number of dependent-on-this-module modules
     enum module_states state;             // state of a module
 };

--- a/inc/dpms.h
+++ b/inc/dpms.h
@@ -1,3 +1,1 @@
-#include "bus.h"
-
 void set_dpms_self(void);

--- a/inc/gamma.h
+++ b/inc/gamma.h
@@ -1,3 +1,1 @@
-#include "bus.h"
-
 void set_gamma_self(void);

--- a/inc/gamma_smooth.h
+++ b/inc/gamma_smooth.h
@@ -1,5 +1,3 @@
-#include "bus.h"
-
 void set_gamma_smooth_self(void);
 void start_gamma_transition(long delay);
 int set_temp(int temp);

--- a/inc/network.h
+++ b/inc/network.h
@@ -1,0 +1,4 @@
+#include "bus.h"
+
+void set_network_self(void);
+int network_enabled(const enum NMState nmstate);

--- a/inc/weather.h
+++ b/inc/weather.h
@@ -1,2 +1,1 @@
 void set_weather_self(void);
-unsigned int get_weather_aware_timeout(const int timeout);

--- a/inc/weather.h
+++ b/inc/weather.h
@@ -1,0 +1,2 @@
+void set_weather_self(void);
+unsigned int get_weather_aware_timeout(const int timeout);

--- a/makefile
+++ b/makefile
@@ -19,8 +19,8 @@ INSTALL_PROGRAM = $(INSTALL) -m755
 INSTALL_DATA = $(INSTALL) -m644
 INSTALL_DIR = $(INSTALL) -d
 SRCDIR = src/
-LIBS = -lm $(shell pkg-config --libs libsystemd popt gsl libconfig libcurl jansson)
-CFLAGS = $(shell pkg-config --cflags libsystemd popt gsl libconfig libcurl jansson) -DCONFDIR=\"$(CONFDIR)\" -D_GNU_SOURCE -std=c99
+LIBS = -lm $(shell pkg-config --libs libsystemd popt gsl libconfig)
+CFLAGS = $(shell pkg-config --cflags libsystemd popt gsl libconfig) -DCONFDIR=\"$(CONFDIR)\" -D_GNU_SOURCE -std=c99
 
 ifeq (,$(findstring $(MAKECMDGOALS),"clean install uninstall"))
 

--- a/makefile
+++ b/makefile
@@ -39,7 +39,7 @@ all: clight clean
 debug: clight-debug clean
 
 objects:
-	@cd $(SRCDIR); $(CC) -c *.c $(CFLAGS)
+	@cd $(SRCDIR); $(CC) -c *.c $(CFLAGS) -O3
 
 objects-debug:
 	@cd $(SRCDIR); $(CC) -c *.c -Wall $(CFLAGS) -Wshadow -Wstrict-overflow -Wtype-limits -fno-strict-aliasing -Wformat -Wformat-security -g

--- a/makefile
+++ b/makefile
@@ -19,8 +19,8 @@ INSTALL_PROGRAM = $(INSTALL) -m755
 INSTALL_DATA = $(INSTALL) -m644
 INSTALL_DIR = $(INSTALL) -d
 SRCDIR = src/
-LIBS = -lm $(shell pkg-config --libs libsystemd popt gsl libconfig)
-CFLAGS = $(shell pkg-config --cflags libsystemd popt gsl libconfig) -DCONFDIR=\"$(CONFDIR)\" -D_GNU_SOURCE -std=c99
+LIBS = -lm $(shell pkg-config --libs libsystemd popt gsl libconfig libcurl jansson)
+CFLAGS = $(shell pkg-config --cflags libsystemd popt gsl libconfig libcurl jansson) -DCONFDIR=\"$(CONFDIR)\" -D_GNU_SOURCE -std=c99
 
 ifeq (,$(findstring $(MAKECMDGOALS),"clean install uninstall"))
 

--- a/makefile
+++ b/makefile
@@ -20,7 +20,7 @@ INSTALL_DATA = $(INSTALL) -m644
 INSTALL_DIR = $(INSTALL) -d
 SRCDIR = src/
 LIBS = -lm $(shell pkg-config --libs libsystemd popt gsl libconfig)
-CFLAGS = $(shell pkg-config --cflags libsystemd popt gsl libconfig) -DCONFDIR=\"$(CONFDIR)\" -D_GNU_SOURCE -std=c99
+CFLAGS = $(shell pkg-config --cflags libsystemd popt gsl libconfig) -DCONFDIR=\"$(CONFDIR)\" -D_GNU_SOURCE -std=c11
 
 ifeq (,$(findstring $(MAKECMDGOALS),"clean install uninstall"))
 

--- a/src/brightness.c
+++ b/src/brightness.c
@@ -196,7 +196,7 @@ static void polynomialfit(enum ac_states s) {
     for(i = 0; i < DEGREE; i++) {
         state.fit_parameters[s][i] = gsl_vector_get(c, i);
     }
-    DEBUG("%d: y = %lf + %lfx + %lfx^2\n", s, state.fit_parameters[s][0], 
+    DEBUG("%s curve: y = %lf + %lfx + %lfx^2\n", s == 0 ? "AC" : "BATT", state.fit_parameters[s][0], 
           state.fit_parameters[s][1], state.fit_parameters[s][2]);
     
     gsl_multifit_linear_free(ws);

--- a/src/brightness.c
+++ b/src/brightness.c
@@ -56,6 +56,7 @@ static void destroy(void) {
 static void callback(void) {
     uint64_t t;
     read(main_p[self.idx].fd, &t, sizeof(uint64_t));
+    
     do_capture();
     if (conf.single_capture_mode) {
         state.quit = NORM_QUIT;

--- a/src/brightness.c
+++ b/src/brightness.c
@@ -106,7 +106,7 @@ static void do_capture(void) {
         state.fast_recapture = 1;
     } else if (!conf.single_capture_mode) {
         // reset normal timer
-        set_timeout(get_weather_aware_timeout(conf.timeout[state.ac_state][state.time]), 0, main_p[self.idx].fd, 0);
+        set_timeout(conf.timeout[state.ac_state][state.time], 0, main_p[self.idx].fd, 0);
     }
 }
 

--- a/src/brightness.c
+++ b/src/brightness.c
@@ -1,5 +1,6 @@
 #include "../inc/brightness.h"
 #include "../inc/bus.h"
+#include "../inc/weather.h"
 #include <gsl/gsl_multifit.h>
 #include <gsl/gsl_statistics_double.h>
 
@@ -16,7 +17,7 @@ static void polynomialfit(enum ac_states state);
 static double clamp(double value, double max, double min);
 static void upower_callback(const void *ptr);
 
-static struct dependency dependencies[] = { {HARD, BUS}, {SOFT, GAMMA}, {SOFT, UPOWER} };
+static struct dependency dependencies[] = { {HARD, BUS}, {SOFT, GAMMA}, {SOFT, UPOWER}, {SOFT, WEATHER} };
 static struct self_t self = {
     .name = "Brightness",
     .idx = BRIGHTNESS,
@@ -104,7 +105,7 @@ static void do_capture(void) {
         state.fast_recapture = 1;
     } else if (!conf.single_capture_mode) {
         // reset normal timer
-        set_timeout(conf.timeout[state.ac_state][state.time], 0, main_p[self.idx].fd, 0);
+        set_timeout(get_weather_aware_timeout(conf.timeout[state.ac_state][state.time]), 0, main_p[self.idx].fd, 0);
     }
 }
 

--- a/src/clight.c
+++ b/src/clight.c
@@ -55,8 +55,7 @@ static void (*const set_selfs[])(void) = {
     set_userbus_self, set_weather_self, set_network_self
 };
 
-#define RATIO sizeof(set_selfs) / sizeof(void (*const)(void))
-_Static_assert(MODULES_NUM == RATIO, "Wrong number of set_selfs() function pointers in clight.c");
+_Static_assert(MODULES_NUM == SIZE(set_selfs), "Wrong number of set_selfs() function pointers in clight.c");
 
 int main(int argc, char *argv[]) {
     state.quit = setjmp(state.quit_buf);

--- a/src/clight.c
+++ b/src/clight.c
@@ -131,9 +131,10 @@ static void main_poll(void) {
             ERROR("%s\n", strerror(errno));
         }
 
-        for (int i = 0; i < MODULES_NUM && !state.quit; i++) {
+        for (int i = 0; i < MODULES_NUM && !state.quit && r > 0; i++) {
             if (main_p[i].revents & POLLIN) {
                 poll_cb(i);
+                r--;
             }
         }
     }

--- a/src/clight.c
+++ b/src/clight.c
@@ -36,6 +36,7 @@
 #include "../inc/xorg.h"
 #include "../inc/inhibit.h"
 #include "../inc/userbus.h"
+#include "../inc/weather.h"
 
 static void init(int argc, char *argv[]);
 static void set_modules_selfs(void);
@@ -49,7 +50,8 @@ static void main_poll(void);
 static void (*const set_selfs[MODULES_NUM])(void) = {
     set_brightness_self, set_location_self, set_upower_self, set_gamma_self,
     set_gamma_smooth_self, set_signal_self, set_bus_self, set_dimmer_self,
-    set_dimmer_smooth_self, set_dpms_self, set_xorg_self, set_inhibit_self, set_userbus_self
+    set_dimmer_smooth_self, set_dpms_self, set_xorg_self, set_inhibit_self, 
+    set_userbus_self, set_weather_self
 };
 
 int main(int argc, char *argv[]) {

--- a/src/clight.c
+++ b/src/clight.c
@@ -128,13 +128,9 @@ static void main_poll(void) {
             ERROR("%s\n", strerror(errno));
         }
 
-        while (r > 0 && !state.quit) {
-            for (int i = 0; i < MODULES_NUM; i++) {
-                if (main_p[i].revents & POLLIN) {
-                    poll_cb(i);
-                    r--;
-                    break;
-                }
+        for (int i = 0; i < MODULES_NUM && !state.quit; i++) {
+            if (main_p[i].revents & POLLIN) {
+                poll_cb(i);
             }
         }
     }

--- a/src/clight.c
+++ b/src/clight.c
@@ -37,6 +37,7 @@
 #include "../inc/inhibit.h"
 #include "../inc/userbus.h"
 #include "../inc/weather.h"
+#include "../inc/network.h"
 
 static void init(int argc, char *argv[]);
 static void set_modules_selfs(void);
@@ -47,12 +48,15 @@ static void main_poll(void);
 /*
  * pointers to init modules functions;
  */
-static void (*const set_selfs[MODULES_NUM])(void) = {
+static void (*const set_selfs[])(void) = {
     set_brightness_self, set_location_self, set_upower_self, set_gamma_self,
     set_gamma_smooth_self, set_signal_self, set_bus_self, set_dimmer_self,
     set_dimmer_smooth_self, set_dpms_self, set_xorg_self, set_inhibit_self, 
-    set_userbus_self, set_weather_self
+    set_userbus_self, set_weather_self, set_network_self
 };
+
+#define RATIO sizeof(set_selfs) / sizeof(void (*const)(void))
+_Static_assert(MODULES_NUM == RATIO, "Wrong number of set_selfs() function pointers in clight.c");
 
 int main(int argc, char *argv[]) {
     state.quit = setjmp(state.quit_buf);

--- a/src/config.c
+++ b/src/config.c
@@ -22,7 +22,7 @@ static void init_config_file(enum CONFIG file) {
 
 void read_config(enum CONFIG file) {
     config_t cfg;
-    const char *videodev, *screendev, *sunrise, *sunset;
+    const char *videodev, *screendev, *sunrise, *sunset, *apikey;
     
     init_config_file(file);
     if (access(config_file, F_OK) == -1) {
@@ -55,6 +55,9 @@ void read_config(enum CONFIG file) {
         }
         if (config_lookup_string(&cfg, "sunset", &sunset) == CONFIG_TRUE) {
             strncpy(conf.events[SUNSET], sunset, sizeof(conf.events[SUNSET]) - 1);
+        }
+        if (config_lookup_string(&cfg, "weather_apikey", &apikey) == CONFIG_TRUE) {
+            strncpy(conf.weather_apikey, apikey, sizeof(conf.weather_apikey) - 1);
         }
         
         config_setting_t *points, *root, *timeouts, *gamma;
@@ -134,6 +137,17 @@ void read_config(enum CONFIG file) {
                 }
             } else {
                 WARN("Wrong number of dimmer_timeouts array elements.\n");
+            }
+        }
+        
+        /* Load weather timeouts */
+        if ((timeouts = config_setting_get_member(root, "weather_timeouts"))) {
+            if (config_setting_length(timeouts) == SIZE_AC) {
+                for (int i = 0; i < SIZE_AC; i++) {
+                    conf.weather_timeout[i] = config_setting_get_int_elem(timeouts, i);
+                }
+            } else {
+                WARN("Wrong number of weather_timeouts array elements.\n");
             }
         }
         

--- a/src/config.c
+++ b/src/config.c
@@ -42,6 +42,7 @@ void read_config(enum CONFIG file) {
         config_lookup_int(&cfg, "dimmer_pct", &conf.dimmer_pct);
         config_lookup_int(&cfg, "no_dpms", (int *)&modules[DPMS].state);
         config_lookup_int(&cfg, "no_inhibit", (int *)&modules[INHIBIT].state);
+        config_lookup_int(&cfg, "no_weather", (int *)&modules[WEATHER].state);
         config_lookup_int(&cfg, "verbose", &conf.verbose);
         
         if (config_lookup_string(&cfg, "video_devname", &videodev) == CONFIG_TRUE) {

--- a/src/dimmer.c
+++ b/src/dimmer.c
@@ -165,8 +165,9 @@ static void upower_callback(const void *ptr) {
  * If we're inhibited, disarm timer (pausing this module)
  * else restart module with its default timeout
  */
-static void inhibit_callback(__attribute__((unused)) const void *ptr) {
-    if (conf.dimmer_timeout[state.ac_state] > 0) {
+static void inhibit_callback(const void *ptr) {
+    int old_pm_state = *(int *)ptr;
+    if (old_pm_state != state.pm_inhibited && conf.dimmer_timeout[state.ac_state] > 0) {
         DEBUG("Dimmer module being %s.\n", state.pm_inhibited ? "paused" : "restarted");
         set_timeout(conf.dimmer_timeout[state.ac_state] * !state.pm_inhibited, 0, main_p[self.idx].fd, 0);
     }

--- a/src/gamma.c
+++ b/src/gamma.c
@@ -1,6 +1,7 @@
 #include "../inc/gamma.h"
 #include "../inc/gamma_smooth.h"
 #include "../inc/location.h"
+#include "../inc/bus.h"
 
 #define ZENITH -0.83
 

--- a/src/gamma.c
+++ b/src/gamma.c
@@ -96,7 +96,7 @@ static void check_gamma(void) {
     t = state.events[state.next_event] + state.event_time_range;
     INFO("Next gamma alarm due to: %s", ctime(&t));
     set_timeout(t, 0, main_p[self.idx].fd, TFD_TIMER_ABSTIME);
-
+    
     /* if we entered/left an event, set correct timeout to BRIGHTNESS */
     if (old_state != state.time && is_inited(BRIGHTNESS) && !state.fast_recapture) {
         reset_timer(main_p[BRIGHTNESS].fd, conf.timeout[state.ac_state][old_state], conf.timeout[state.ac_state][state.time]);

--- a/src/gamma_smooth.c
+++ b/src/gamma_smooth.c
@@ -1,4 +1,5 @@
 #include "../inc/gamma_smooth.h"
+#include "../inc/bus.h"
 
 #define GAMMA_SMOOTH_TIMEOUT 300 * 1000 * 1000  // 300 ms
 

--- a/src/inhibit.c
+++ b/src/inhibit.c
@@ -62,6 +62,9 @@ static int inhibit_init(void) {
 static int on_inhibit_change(__attribute__((unused)) sd_bus_message *m, void *userdata, __attribute__((unused)) sd_bus_error *ret_error) {
     struct bus_match_data *data = (struct bus_match_data *) userdata;
     data->bus_mod_idx = self.idx;
+    /* Fill data->ptr with old inhibit state */
+    data->ptr = malloc(sizeof(int));
+    *(int *)(data->ptr) = state.pm_inhibited;
 
     struct bus_args args = {"org.freedesktop.PowerManagement.Inhibit", "/org/freedesktop/PowerManagement/Inhibit", "org.freedesktop.PowerManagement.Inhibit", "HasInhibit", USER};
     call(&state.pm_inhibited, "b", &args, "");

--- a/src/location.c
+++ b/src/location.c
@@ -167,6 +167,9 @@ static int geoclue_hook_update(void) {
 static int on_geoclue_new_location(sd_bus_message *m, void *userdata, __attribute__((unused)) sd_bus_error *ret_error) {
     struct bus_match_data *data = (struct bus_match_data *) userdata;
     data->bus_mod_idx = self.idx;
+    /* Fill data->ptr with old latitude/longitude */
+    data->ptr = malloc(2 * sizeof(double));
+    memcpy(data->ptr, (double[]){ conf.lat, conf.lon }, 2 * sizeof(double));
     
     const char *new_location, *old_location;
     sd_bus_message_read(m, "oo", &old_location, &new_location);

--- a/src/location.c
+++ b/src/location.c
@@ -132,6 +132,13 @@ static int check(void) {
      */
     if ((strlen(conf.events[SUNRISE]) && strlen(conf.events[SUNSET])) || (conf.lat != 0.0 && conf.lon != 0.0)) {
         change_dep_type(GAMMA, self.idx, SOFT);
+        /* 
+         * weather requires lat or lon, so do not disable it if they're provided.
+         * But disable it if sunrise or sunset times are set fixed by user.
+         */
+        if (conf.lat != 0.0 && conf.lon != 0.0) {
+            change_dep_type(WEATHER, self.idx, SOFT);
+        }
         return 1;
     }
     return !is_idle(GAMMA) && !is_inited(GAMMA);

--- a/src/log.c
+++ b/src/log.c
@@ -23,28 +23,31 @@ void log_conf(void) {
         fprintf(log_file, "Starting time: %s\n", ctime(&t));
         if (!conf.single_capture_mode) {
             fprintf(log_file, "Starting options:\n");
-            fprintf(log_file, "* Verbose (debugging):\t\t%s\n", conf.verbose ? "enabled" : "disabled");
+            fprintf(log_file, "* Verbose (debugging):\t\t%s\n", conf.verbose ? "Enabled" : "Disabled");
             fprintf(log_file, "* Number of captures:\t\t%d\n", conf.num_captures);
             fprintf(log_file, "* Daily timeouts:\t\tAC %d\tBATT %d\n", conf.timeout[ON_AC][DAY], conf.timeout[ON_BATTERY][DAY]);
             fprintf(log_file, "* Nightly timeout:\t\tAC %d\tBATT %d\n", conf.timeout[ON_AC][NIGHT], conf.timeout[ON_BATTERY][NIGHT]);
             fprintf(log_file, "* Event timeouts:\t\tAC %d\tBATT %d\n", conf.timeout[ON_AC][EVENT], conf.timeout[ON_BATTERY][EVENT]);
-            fprintf(log_file, "* Webcam device:\t\t%s\n", conf.dev_name);
-            fprintf(log_file, "* Backlight path:\t\t%s\n", conf.screen_path);
+            fprintf(log_file, "* Webcam device:\t\t%s\n", strlen(conf.dev_name) ? conf.dev_name : "Not setted");
+            fprintf(log_file, "* Backlight path:\t\t%s\n", strlen(conf.screen_path) ? conf.screen_path : "Not setted");
             fprintf(log_file, "* Daily screen temp:\t\t%d\n", conf.temp[DAY]);
             fprintf(log_file, "* Nightly screen temp:\t\t%d\n", conf.temp[NIGHT]);
-            fprintf(log_file, "* Gamma smooth trans:\t\t%s\n", is_started_disabled(GAMMA_SMOOTH) ? "disabled" : "enabled");
-            fprintf(log_file, "* Dimmer smooth trans:\t\t%s\n", is_started_disabled(DIMMER_SMOOTH) ? "disabled" : "enabled");
-            fprintf(log_file, "* User latitude:\t\t%.2lf\n", conf.lat);
-            fprintf(log_file, "* User longitude:\t\t%.2lf\n", conf.lon);
-            fprintf(log_file, "* User setted sunrise:\t\t%s\n", conf.events[SUNRISE]);
-            fprintf(log_file, "* User setted sunset:\t\t%s\n", conf.events[SUNSET]);
-            fprintf(log_file, "* Gamma correction:\t\t%s\n", is_started_disabled(GAMMA) ? "disabled" : "enabled");
+            fprintf(log_file, "* Gamma smooth trans:\t\t%s\n", is_started_disabled(GAMMA_SMOOTH) ? "Disabled" : "Enabled");
+            fprintf(log_file, "* Dimmer smooth trans:\t\t%s\n", is_started_disabled(DIMMER_SMOOTH) ? "Disabled" : "Enabled");
+            if (conf.lat != 0.0f || conf.lon != 0.0f) {
+                fprintf(log_file, "* User position:\t\t%.2lf\t%.2lf\n", conf.lat, conf.lon);
+            } else {
+                fprintf(log_file, "* User position:\t\tNot setted\n");
+            }
+            fprintf(log_file, "* User setted sunrise:\t\t%s\n", strlen(conf.events[SUNRISE]) ? conf.events[SUNRISE] : "Not setted");
+            fprintf(log_file, "* User setted sunset:\t\t%s\n", strlen(conf.events[SUNSET]) ? conf.events[SUNSET] : "Not setted");
+            fprintf(log_file, "* Gamma correction:\t\t%s\n", is_started_disabled(GAMMA) ? "Disabled" : "Enabled");
             fprintf(log_file, "* Event duration:\t\t%d\n", conf.event_duration);
-            fprintf(log_file, "* Screen dimmer tool:\t\t%s\n", is_started_disabled(DIMMER) ? "disabled" : "enabled");
+            fprintf(log_file, "* Screen dimmer tool:\t\t%s\n", is_started_disabled(DIMMER) ? "Disabled" : "Enabled");
             fprintf(log_file, "* Dimmer backlight:\t\t%d%%\n", conf.dimmer_pct);
             fprintf(log_file, "* Dimmer timeouts:\t\tAC %d\tBATT %d\n", conf.dimmer_timeout[ON_AC], conf.dimmer_timeout[ON_BATTERY]);
-            fprintf(log_file, "* Screen dpms tool:\t\t%s\n", is_started_disabled(DPMS) ? "disabled" : "enabled");
-            fprintf(log_file, "* Weather support:\t\t%s\n", is_started_disabled(WEATHER) ? "disabled" : "enabled");
+            fprintf(log_file, "* Screen dpms tool:\t\t%s\n", is_started_disabled(DPMS) ? "Disabled" : "Enabled");
+            fprintf(log_file, "* Weather support:\t\t%s\n", is_started_disabled(WEATHER) ? "Disabled" : "Enabled");
             fprintf(log_file, "* Dpms timeouts:\t\tAC %d:%d:%d\tBATT %d:%d:%d\n\n",
                 conf.dpms_timeouts[ON_AC][STANDBY], conf.dpms_timeouts[ON_AC][SUSPEND], conf.dpms_timeouts[ON_AC][OFF],
                 conf.dpms_timeouts[ON_BATTERY][STANDBY], conf.dpms_timeouts[ON_BATTERY][SUSPEND], conf.dpms_timeouts[ON_BATTERY][OFF]

--- a/src/log.c
+++ b/src/log.c
@@ -18,40 +18,48 @@ void log_conf(void) {
     if (log_file) {
         time_t t = time(NULL);
 
-        fprintf(log_file, "Clight\n");
-        fprintf(log_file, "Version: %s\n", VERSION);
-        fprintf(log_file, "Starting time: %s\n", ctime(&t));
+        fprintf(log_file, "Clight\n\n");
+        fprintf(log_file, "* Software version:\t\t%s\n", VERSION);
+        fprintf(log_file, "* Starting time:\t\t%s\n", ctime(&t));
+        fprintf(log_file, "Starting options:\n");
+        fprintf(log_file, "\n### Generic ###\n");
+        fprintf(log_file, "* Verbose (debugging):\t\t%s\n", conf.verbose ? "Enabled" : "Disabled");
+        fprintf(log_file, "* Number of captures:\t\t%d\n", conf.num_captures);
+        fprintf(log_file, "* Webcam device:\t\t%s\n", strlen(conf.dev_name) ? conf.dev_name : "Not setted");
+        fprintf(log_file, "* Backlight path:\t\t%s%s", strlen(conf.screen_path) ? conf.screen_path : "Not setted", conf.single_capture_mode ? "\n\n" : "\n");
+        
         if (!conf.single_capture_mode) {
-            fprintf(log_file, "Starting options:\n");
-            fprintf(log_file, "* Verbose (debugging):\t\t%s\n", conf.verbose ? "Enabled" : "Disabled");
-            fprintf(log_file, "* Number of captures:\t\t%d\n", conf.num_captures);
-            fprintf(log_file, "* Daily timeouts:\t\tAC %d\tBATT %d\n", conf.timeout[ON_AC][DAY], conf.timeout[ON_BATTERY][DAY]);
-            fprintf(log_file, "* Nightly timeout:\t\tAC %d\tBATT %d\n", conf.timeout[ON_AC][NIGHT], conf.timeout[ON_BATTERY][NIGHT]);
-            fprintf(log_file, "* Event timeouts:\t\tAC %d\tBATT %d\n", conf.timeout[ON_AC][EVENT], conf.timeout[ON_BATTERY][EVENT]);
-            fprintf(log_file, "* Webcam device:\t\t%s\n", strlen(conf.dev_name) ? conf.dev_name : "Not setted");
-            fprintf(log_file, "* Backlight path:\t\t%s\n", strlen(conf.screen_path) ? conf.screen_path : "Not setted");
-            fprintf(log_file, "* Daily screen temp:\t\t%d\n", conf.temp[DAY]);
-            fprintf(log_file, "* Nightly screen temp:\t\t%d\n", conf.temp[NIGHT]);
-            fprintf(log_file, "* Gamma smooth trans:\t\t%s\n", is_started_disabled(GAMMA_SMOOTH) ? "Disabled" : "Enabled");
-            fprintf(log_file, "* Dimmer smooth trans:\t\t%s\n", is_started_disabled(DIMMER_SMOOTH) ? "Disabled" : "Enabled");
             if (conf.lat != 0.0f || conf.lon != 0.0f) {
                 fprintf(log_file, "* User position:\t\t%.2lf\t%.2lf\n", conf.lat, conf.lon);
             } else {
                 fprintf(log_file, "* User position:\t\tNot setted\n");
             }
+            fprintf(log_file, "* Daily screen temp:\t\t%d\n", conf.temp[DAY]);
+            fprintf(log_file, "* Nightly screen temp:\t\t%d\n", conf.temp[NIGHT]);
             fprintf(log_file, "* User setted sunrise:\t\t%s\n", strlen(conf.events[SUNRISE]) ? conf.events[SUNRISE] : "Not setted");
             fprintf(log_file, "* User setted sunset:\t\t%s\n", strlen(conf.events[SUNSET]) ? conf.events[SUNSET] : "Not setted");
-            fprintf(log_file, "* Gamma correction:\t\t%s\n", is_started_disabled(GAMMA) ? "Disabled" : "Enabled");
+            
             fprintf(log_file, "* Event duration:\t\t%d\n", conf.event_duration);
-            fprintf(log_file, "* Screen dimmer tool:\t\t%s\n", is_started_disabled(DIMMER) ? "Disabled" : "Enabled");
             fprintf(log_file, "* Dimmer backlight:\t\t%d%%\n", conf.dimmer_pct);
+            
+            fprintf(log_file, "\n### Timeouts ###\n");
+            fprintf(log_file, "* Daily timeouts:\t\tAC %d\tBATT %d\n", conf.timeout[ON_AC][DAY], conf.timeout[ON_BATTERY][DAY]);
+            fprintf(log_file, "* Nightly timeout:\t\tAC %d\tBATT %d\n", conf.timeout[ON_AC][NIGHT], conf.timeout[ON_BATTERY][NIGHT]);
+            fprintf(log_file, "* Event timeouts:\t\tAC %d\tBATT %d\n", conf.timeout[ON_AC][EVENT], conf.timeout[ON_BATTERY][EVENT]);
             fprintf(log_file, "* Dimmer timeouts:\t\tAC %d\tBATT %d\n", conf.dimmer_timeout[ON_AC], conf.dimmer_timeout[ON_BATTERY]);
+            fprintf(log_file, "* Weather timeouts:\t\tAC %d\tBATT %d\n", conf.weather_timeout[ON_AC], conf.weather_timeout[ON_BATTERY]);
+            fprintf(log_file, "* Dpms timeouts:\t\tAC %d:%d:%d\tBATT %d:%d:%d\n",
+                    conf.dpms_timeouts[ON_AC][STANDBY], conf.dpms_timeouts[ON_AC][SUSPEND], conf.dpms_timeouts[ON_AC][OFF],
+                    conf.dpms_timeouts[ON_BATTERY][STANDBY], conf.dpms_timeouts[ON_BATTERY][SUSPEND], conf.dpms_timeouts[ON_BATTERY][OFF]
+            );
+            
+            fprintf(log_file, "\n### Modules ###\n");
+            fprintf(log_file, "* Gamma smooth trans:\t\t%s\n", is_started_disabled(GAMMA_SMOOTH) ? "Disabled" : "Enabled");
+            fprintf(log_file, "* Dimmer smooth trans:\t\t%s\n", is_started_disabled(DIMMER_SMOOTH) ? "Disabled" : "Enabled");
+            fprintf(log_file, "* Gamma correction:\t\t%s\n", is_started_disabled(GAMMA) ? "Disabled" : "Enabled");
             fprintf(log_file, "* Screen dpms tool:\t\t%s\n", is_started_disabled(DPMS) ? "Disabled" : "Enabled");
             fprintf(log_file, "* Weather support:\t\t%s\n", is_started_disabled(WEATHER) ? "Disabled" : "Enabled");
-            fprintf(log_file, "* Dpms timeouts:\t\tAC %d:%d:%d\tBATT %d:%d:%d\n\n",
-                conf.dpms_timeouts[ON_AC][STANDBY], conf.dpms_timeouts[ON_AC][SUSPEND], conf.dpms_timeouts[ON_AC][OFF],
-                conf.dpms_timeouts[ON_BATTERY][STANDBY], conf.dpms_timeouts[ON_BATTERY][SUSPEND], conf.dpms_timeouts[ON_BATTERY][OFF]
-            );
+            fprintf(log_file, "* Screen dimmer tool:\t\t%s\n\n", is_started_disabled(DIMMER) ? "Disabled" : "Enabled");
         }
         fflush(log_file);
     }

--- a/src/log.c
+++ b/src/log.c
@@ -32,18 +32,19 @@ void log_conf(void) {
             fprintf(log_file, "* Backlight path:\t\t%s\n", conf.screen_path);
             fprintf(log_file, "* Daily screen temp:\t\t%d\n", conf.temp[DAY]);
             fprintf(log_file, "* Nightly screen temp:\t\t%d\n", conf.temp[NIGHT]);
-            fprintf(log_file, "* Gamma smooth trans:\t\t%s\n", is_disabled(GAMMA_SMOOTH) ? "disabled" : "enabled");
-            fprintf(log_file, "* Dimmer smooth trans:\t\t%s\n", is_disabled(DIMMER_SMOOTH) ? "disabled" : "enabled");
+            fprintf(log_file, "* Gamma smooth trans:\t\t%s\n", is_started_disabled(GAMMA_SMOOTH) ? "disabled" : "enabled");
+            fprintf(log_file, "* Dimmer smooth trans:\t\t%s\n", is_started_disabled(DIMMER_SMOOTH) ? "disabled" : "enabled");
             fprintf(log_file, "* User latitude:\t\t%.2lf\n", conf.lat);
             fprintf(log_file, "* User longitude:\t\t%.2lf\n", conf.lon);
             fprintf(log_file, "* User setted sunrise:\t\t%s\n", conf.events[SUNRISE]);
             fprintf(log_file, "* User setted sunset:\t\t%s\n", conf.events[SUNSET]);
-            fprintf(log_file, "* Gamma correction:\t\t%s\n", is_disabled(GAMMA) ? "disabled" : "enabled");
+            fprintf(log_file, "* Gamma correction:\t\t%s\n", is_started_disabled(GAMMA) ? "disabled" : "enabled");
             fprintf(log_file, "* Event duration:\t\t%d\n", conf.event_duration);
-            fprintf(log_file, "* Screen dimmer tool:\t\t%s\n", is_disabled(DIMMER) ? "disabled" : "enabled");
+            fprintf(log_file, "* Screen dimmer tool:\t\t%s\n", is_started_disabled(DIMMER) ? "disabled" : "enabled");
             fprintf(log_file, "* Dimmer backlight:\t\t%d%%\n", conf.dimmer_pct);
             fprintf(log_file, "* Dimmer timeouts:\t\tAC %d\tBATT %d\n", conf.dimmer_timeout[ON_AC], conf.dimmer_timeout[ON_BATTERY]);
-            fprintf(log_file, "* Screen dpms tool:\t\t%s\n", is_disabled(DPMS) ? "disabled" : "enabled");
+            fprintf(log_file, "* Screen dpms tool:\t\t%s\n", is_started_disabled(DPMS) ? "disabled" : "enabled");
+            fprintf(log_file, "* Weather support:\t\t%s\n", is_started_disabled(WEATHER) ? "disabled" : "enabled");
             fprintf(log_file, "* Dpms timeouts:\t\tAC %d:%d:%d\tBATT %d:%d:%d\n\n",
                 conf.dpms_timeouts[ON_AC][STANDBY], conf.dpms_timeouts[ON_AC][SUSPEND], conf.dpms_timeouts[ON_AC][OFF],
                 conf.dpms_timeouts[ON_BATTERY][STANDBY], conf.dpms_timeouts[ON_BATTERY][SUSPEND], conf.dpms_timeouts[ON_BATTERY][OFF]
@@ -69,7 +70,7 @@ void log_message(const char *filename, int lineno, const char type, const char *
         fflush(log_file);
     }
     
-    /* In case of error, set quit flag */
+    /* In case of error, log to stdout too */
     FILE *out = stdout;
     if (type == 'E') {
         out = stderr;

--- a/src/log.c
+++ b/src/log.c
@@ -38,7 +38,6 @@ void log_conf(void) {
             fprintf(log_file, "* Nightly screen temp:\t\t%d\n", conf.temp[NIGHT]);
             fprintf(log_file, "* User setted sunrise:\t\t%s\n", strlen(conf.events[SUNRISE]) ? conf.events[SUNRISE] : "Not setted");
             fprintf(log_file, "* User setted sunset:\t\t%s\n", strlen(conf.events[SUNSET]) ? conf.events[SUNSET] : "Not setted");
-            
             fprintf(log_file, "* Event duration:\t\t%d\n", conf.event_duration);
             fprintf(log_file, "* Dimmer backlight:\t\t%d%%\n", conf.dimmer_pct);
             

--- a/src/modules.c
+++ b/src/modules.c
@@ -65,7 +65,7 @@ void init_module(int fd, enum modules module, ...) {
         while (cb) {
             if (is_inited(cb->module)) {
                 add_mod_callback(*cb);
-                DEBUG("Callback added for module %d on module %d bus match.\n", module, cb->module);
+                DEBUG("Callback added for module %s on module %s bus match.\n", modules[module].self->name, modules[cb->module].self->name);
             }
             cb = va_arg(args, struct bus_cb *);
         }

--- a/src/network.c
+++ b/src/network.c
@@ -1,0 +1,82 @@
+#include "../inc/network.h"
+
+static void init(void);
+static int check(void);
+static void callback(void);
+static void destroy(void);
+static int network_init(void);
+static int on_network_change(sd_bus_message *m, void *userdata, sd_bus_error *ret_error);
+
+static sd_bus_slot *slot;
+static struct dependency dependencies[] = { {HARD, BUS} };
+static struct self_t self = {
+    .name = "Network",
+    .idx = NETWORK,
+    .num_deps = SIZE(dependencies),
+    .deps =  dependencies
+};
+
+void set_network_self(void) {
+    SET_SELF();
+}
+
+static void init(void) {
+    int r = network_init();
+    /* In case of errors, upower_init returns -1 -> disable upower. */
+    INIT_MOD(r == 0 ? DONT_POLL : DONT_POLL_W_ERR);
+}
+
+static int check(void) {
+    return 0; /* Skeleton function needed for modules interface */
+}
+
+static void callback(void) {
+    // Skeleton interface
+}
+
+static void destroy(void) {
+    /* Destroy this match slot */
+    if (slot) {
+        sd_bus_slot_unref(slot);
+    }
+}
+
+static int network_init(void) {
+    /* check initial AC state */
+    struct bus_args network_args = {"org.freedesktop.NetworkManager",  "/org/freedesktop/NetworkManager", "org.freedesktop.NetworkManager", "State"};
+    int r = get_property(&network_args, "u", &state.nmstate);
+    if (r < 0) {
+        WARN("NetworkManager appears to be unsupported.\n");
+        return -1;   // disable this module
+    }
+    struct bus_args args = {"org.freedesktop.NetworkManager",  "/org/freedesktop/NetworkManager", "org.freedesktop.NetworkManager", "StateChanged"};
+    r = add_match(&args, &slot, on_network_change);
+    return -(r < 0);
+}
+
+/* 
+ * Callback on network changes: recheck networkmanager state value
+ */
+static int on_network_change(__attribute__((unused)) sd_bus_message *m, void *userdata, __attribute__((unused)) sd_bus_error *ret_error) {
+    struct bus_match_data *data = (struct bus_match_data *) userdata;
+    data->bus_mod_idx = self.idx;
+    /* Fill data->ptr with old networkmanager state */
+    data->ptr = malloc(sizeof(int));
+    *(int *)(data->ptr) = state.nmstate;
+    
+    struct bus_args network_args = {"org.freedesktop.NetworkManager",  "/org/freedesktop/NetworkManager", "org.freedesktop.NetworkManager", "State"};
+    get_property(&network_args, "u", &state.nmstate);
+    if (*(int *)(data->ptr) != state.nmstate) {
+        INFO("New network state: %u.\n", state.nmstate);
+    }
+    return 0;
+}
+
+/*
+ * Returns network enabled boolean for a given NMState state.
+ * Note that in case this module is disabled,
+ * we assume network is always on.
+ */
+int network_enabled(const enum NMState nmstate) {
+    return nmstate == NM_STATE_CONNECTED_GLOBAL || is_disabled(self.idx);
+}

--- a/src/network.c
+++ b/src/network.c
@@ -67,7 +67,7 @@ static int on_network_change(__attribute__((unused)) sd_bus_message *m, void *us
     struct bus_args network_args = {"org.freedesktop.NetworkManager",  "/org/freedesktop/NetworkManager", "org.freedesktop.NetworkManager", "State"};
     get_property(&network_args, "u", &state.nmstate);
     if (*(int *)(data->ptr) != state.nmstate) {
-        INFO("New network state: %u.\n", state.nmstate);
+        DEBUG("New network state: %u.\n", state.nmstate);
     }
     return 0;
 }

--- a/src/opts.c
+++ b/src/opts.c
@@ -27,8 +27,8 @@ void init_opts(int argc, char *argv[]) {
     conf.dimmer_timeout[ON_AC] = 300;
     conf.dimmer_timeout[ON_BATTERY] = 45;
     conf.dimmer_pct = 20;
-    conf.weather_timeout[ON_AC] = 6 * 60 * 60;
-    conf.weather_timeout[ON_BATTERY] = 6 * 60 * 60;
+    conf.weather_timeout[ON_AC] = 60 * 60;
+    conf.weather_timeout[ON_BATTERY] = 3 * 60 * 60;
     
     /*
      * Default polynomial regression points:
@@ -204,11 +204,11 @@ static void check_conf(void) {
     }
     if (conf.weather_timeout[ON_AC] <= 0) {
         WARN("Wrong AC weather timeout. Resetting default value.\n");
-        conf.weather_timeout[ON_AC] = 6 * 60 * 60;
+        conf.weather_timeout[ON_AC] = 60 * 60;
     }
     if (conf.weather_timeout[ON_BATTERY] <= 0) {
         WARN("Wrong BATT weather timeout. Resetting default value.\n");
-        conf.weather_timeout[ON_BATTERY] = 6 * 60 * 60;
+        conf.weather_timeout[ON_BATTERY] = 3 * 60 * 60;
     }
     
     int i, reg_points_ac_needed = 0, reg_points_batt_needed = 0;

--- a/src/opts.c
+++ b/src/opts.c
@@ -27,6 +27,8 @@ void init_opts(int argc, char *argv[]) {
     conf.dimmer_timeout[ON_AC] = 300;
     conf.dimmer_timeout[ON_BATTERY] = 45;
     conf.dimmer_pct = 20;
+    conf.weather_timeout[ON_AC] = 6 * 60 * 60;
+    conf.weather_timeout[ON_BATTERY] = 6 * 60 * 60;
     
     /*
      * Default polynomial regression points:
@@ -100,6 +102,8 @@ static void parse_cmd(int argc, char *const argv[]) {
         {"batt-dimmer-timeout", 0, POPT_ARG_INT | POPT_ARGFLAG_SHOW_DEFAULT, &conf.dimmer_timeout[ON_BATTERY], 100, "Seconds of inactivity before dimmin screen on battery", NULL},
         {"no-dpms", 0, POPT_ARG_NONE, &modules[DPMS].state, 100, "Disable dpms tool", NULL},
         {"no-inhibit", 0, POPT_ARG_NONE, &modules[INHIBIT].state, 100, "Disable org.freedesktop.PowerManagement.Inhibit support", NULL},
+        {"no-weather", 0, POPT_ARG_NONE, &modules[WEATHER].state, 100, "Disable weather support", NULL},
+        {"apikey", 0, POPT_ARG_STRING, NULL, 6, "Openweathermap apikey for weather support", NULL},
         {"verbose", 0, POPT_ARG_NONE, &conf.verbose, 100, "Enable verbose mode", NULL},
         {"version", 'v', POPT_ARG_NONE, NULL, 5, "Show version info", NULL},
         POPT_AUTOHELP
@@ -126,6 +130,9 @@ static void parse_cmd(int argc, char *const argv[]) {
             case 5:
                 printf("%s version: %s\n", argv[0], VERSION);
                 exit(EXIT_SUCCESS);
+            case 6:
+                strncpy(conf.weather_apikey, str, sizeof(conf.weather_apikey) - 1);
+                break;
             default:
                 break;
         }
@@ -194,6 +201,14 @@ static void check_conf(void) {
     if (conf.dimmer_pct > 100 || conf.dimmer_pct < 0) {
         WARN("Wrong dimmer backlight percentage value. Resetting default value.\n");
         conf.dimmer_pct = 20;
+    }
+    if (conf.weather_timeout[ON_AC] <= 0) {
+        WARN("Wrong AC weather timeout. Resetting default value.\n");
+        conf.weather_timeout[ON_AC] = 6 * 60 * 60;
+    }
+    if (conf.weather_timeout[ON_BATTERY] <= 0) {
+        WARN("Wrong BATT weather timeout. Resetting default value.\n");
+        conf.weather_timeout[ON_BATTERY] = 6 * 60 * 60;
     }
     
     int i, reg_points_ac_needed = 0, reg_points_batt_needed = 0;

--- a/src/opts.c
+++ b/src/opts.c
@@ -103,7 +103,7 @@ static void parse_cmd(int argc, char *const argv[]) {
         {"no-dpms", 0, POPT_ARG_NONE, &modules[DPMS].state, 100, "Disable dpms tool", NULL},
         {"no-inhibit", 0, POPT_ARG_NONE, &modules[INHIBIT].state, 100, "Disable org.freedesktop.PowerManagement.Inhibit support", NULL},
         {"no-weather", 0, POPT_ARG_NONE, &modules[WEATHER].state, 100, "Disable weather support", NULL},
-        {"apikey", 0, POPT_ARG_STRING, NULL, 6, "Openweathermap apikey for weather support", NULL},
+        {"apikey", 0, POPT_ARG_STRING, NULL, 6, "OpenWeatherMap apikey for weather support", NULL},
         {"verbose", 0, POPT_ARG_NONE, &conf.verbose, 100, "Enable verbose mode", NULL},
         {"version", 'v', POPT_ARG_NONE, NULL, 5, "Show version info", NULL},
         POPT_AUTOHELP

--- a/src/upower.c
+++ b/src/upower.c
@@ -62,6 +62,7 @@ static int upower_init(void) {
 static int on_upower_change(__attribute__((unused)) sd_bus_message *m, void *userdata, __attribute__((unused)) sd_bus_error *ret_error) {
     struct bus_match_data *data = (struct bus_match_data *) userdata;
     data->bus_mod_idx = self.idx;
+    /* Fill data->ptr with old ac state */
     data->ptr = malloc(sizeof(int));
     *(int *)(data->ptr) = state.ac_state;
     

--- a/src/upower.c
+++ b/src/upower.c
@@ -77,9 +77,8 @@ static int on_upower_change(__attribute__((unused)) sd_bus_message *m, void *use
      * .LidIsPresent                       property  b         true         emits-change
      * .OnBattery                          property  b         false        emits-change
      */
-    int old_ac_state = state.ac_state;
     get_property(&power_args, "b", &state.ac_state);
-    if (old_ac_state != state.ac_state) {
+    if (*(int *)(data->ptr) != state.ac_state) {
         INFO(state.ac_state ? "Ac cable disconnected. Powersaving mode enabled.\n" : "Ac cable connected. Powersaving mode disabled.\n");
     }
     return 0;

--- a/src/weather.c
+++ b/src/weather.c
@@ -1,0 +1,135 @@
+#include "../inc/weather.h"
+#include "../inc/bus.h"
+#include <curl/curl.h>
+#include <jansson.h>
+
+#define BUFFER_SIZE 2048
+
+struct json_write_result {
+    char data[BUFFER_SIZE];
+    unsigned long position;
+};
+
+static void init(void);
+static int check(void);
+static void callback(void);
+static void destroy(void);
+static void get_weather(void);
+static size_t write_data_buffer(void *ptr, size_t size, size_t nmemb, void *stream);
+static int owm_fetch_remote(struct json_write_result *json);
+static void parse_json(const char *json);
+static void upower_callback(const void *ptr);
+
+static CURL *handle;
+static struct dependency dependencies[] = { {HARD, LOCATION}, {SOFT, BUS}, {SOFT, UPOWER} };
+static struct self_t self = {
+    .name = "Weather",
+    .idx = WEATHER,
+    .num_deps = SIZE(dependencies),
+    .deps =  dependencies
+};
+
+void set_weather_self(void) {
+    SET_SELF();
+}
+
+static void init(void) {
+    handle = curl_easy_init();
+    if (handle) {
+        struct bus_cb upower_cb = { UPOWER, upower_callback };
+        int fd = start_timer(CLOCK_BOOTTIME, 0, 1);
+        INIT_MOD(fd, &upower_cb);
+    } else {
+        WARN("Could not instantiate curl handle.\n");
+        INIT_MOD(DONT_POLL_W_ERR);
+    }
+}
+
+static int check(void) {
+    return !strlen(conf.weather_apikey);
+}
+
+static void callback(void) {
+    get_weather();
+    set_timeout(conf.weather_timeout[state.ac_state], 0, main_p[self.idx].fd, 0);
+}
+
+static void destroy(void) {
+    if (handle) {
+        curl_easy_cleanup(handle);
+    }
+}
+
+static void get_weather(void) {
+    struct json_write_result json = {{0}};
+    
+    if (!owm_fetch_remote(&json)) {
+        parse_json(json.data);
+    }
+}
+
+/* Callback function for curl */
+static size_t write_data_buffer(void *ptr, size_t size, size_t nmemb, void *stream) {
+    struct json_write_result *result = (struct json_write_result * )stream;
+    if (result->position + size * nmemb >= BUFFER_SIZE - 1) {
+        fprintf(stderr, "Write Buffer is too small\n");
+        return 0;
+    }
+    memcpy(result->data + result->position, ptr, size * nmemb);
+    result->position += size * nmemb;
+    return size * nmemb;
+}
+
+/* Fetch json from openweathermap */
+static int owm_fetch_remote(struct json_write_result *json) {
+    int ret = -1;
+    CURLcode result;
+    
+    char url [512] = {0};
+    const char *provider = "http://api.openweathermap.org/data/2.5/weather";
+        
+    snprintf(url, sizeof(url), "%s?lat=%lf&lon=%lf&units=metric&APPID=%s", provider, conf.lat, conf.lon, conf.weather_apikey);
+        
+    curl_easy_setopt(handle, CURLOPT_URL, url);
+    curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION, write_data_buffer);
+    curl_easy_setopt(handle, CURLOPT_WRITEDATA, json);
+        
+    result = curl_easy_perform(handle);
+    if (result != CURLE_OK) {
+        WARN("Failed to retrieve data (%s)\n", curl_easy_strerror(result));
+    } else {
+        ret = 0;
+    }
+    return ret;
+}
+
+/* Parse json with json_unpack (jansson library) */
+static void parse_json(const char *json) {
+    json_error_t error;
+    json_t *root = json_loads(json, 0, &error);
+    if (!root) {
+        WARN("Error on line %d (%s)\n", error.line, error.text);
+    } else {
+        if (json_unpack(root, "{s:{s:i}}", "clouds", "all", &state.cloudiness)) {
+            WARN("Failed to find cloudiness in json.\n");
+        } else {
+            DEBUG("Cloudiness: %d\n", state.cloudiness);
+        }
+    }
+    json_decref(root);
+}
+
+static void upower_callback(const void *ptr) {
+    int old_ac_state = *(int *)ptr;
+    /* Force check that we received an ac_state changed event for real */
+    if (old_ac_state != state.ac_state) {
+        reset_timer(main_p[self.idx].fd, conf.weather_timeout[old_ac_state], conf.weather_timeout[state.ac_state]);
+    }
+}
+
+unsigned int get_weather_aware_timeout(const int timeout) {
+    if (state.cloudiness > 50) {
+        return timeout * (1 - (double)(state.cloudiness - 50) / 100);
+    }
+    return timeout;
+}

--- a/src/weather.c
+++ b/src/weather.c
@@ -15,7 +15,7 @@ static void upower_callback(const void *ptr);
 static unsigned int get_weather_aware_timeout(int timeout);
 
 static int brightness_timeouts[SIZE_AC][SIZE_STATES];
-static struct dependency dependencies[] = { {HARD, LOCATION}, {SOFT, BUS}, {SOFT, UPOWER} };
+static struct dependency dependencies[] = { {HARD, LOCATION}, {SOFT, UPOWER} };
 static struct self_t self = {
     .name = "Weather",
     .idx = WEATHER,

--- a/src/weather.c
+++ b/src/weather.c
@@ -149,8 +149,8 @@ static int get_weather(void) {
     int old_cloudiness = state.cloudiness;
     sscanf(strstr(buf, "\"clouds\""), "\"clouds\":{\"all\":%d}", &state.cloudiness);
     DEBUG("Weather cloudiness: %d\n", state.cloudiness);
-    ret = old_cloudiness != state.cloudiness ? 0 : 1;
-    
+    ret = old_cloudiness == state.cloudiness;
+
 end:
     if (sockfd > 0) { 
         close(sockfd);

--- a/src/weather.c
+++ b/src/weather.c
@@ -36,6 +36,9 @@ static int check(void) {
 }
 
 static void callback(void) {
+    uint64_t t;
+    read(main_p[self.idx].fd, &t, sizeof(uint64_t));
+    
     if (!get_weather() && is_inited(BRIGHTNESS)) {
 //         reset_timer(main_p[BRIGHTNESS].fd, conf.timeout[state.ac_state][old_state], conf.timeout[state.ac_state][state.time]);
     }
@@ -47,6 +50,7 @@ static void destroy(void) {
 }
 
 static int get_weather(void) {
+    int ret = -1;
     char header[500] = {0};
     const char *provider = "api.openweathermap.org";
     const char *endpoint = "/data/2.5/weather";
@@ -55,13 +59,13 @@ static int get_weather(void) {
                                     endpoint, conf.lat, conf.lon, conf.weather_apikey, provider);
     
     /* get host info */
-    struct addrinfo hints = {0}, *res;
+    struct addrinfo hints = {0}, *res = NULL;
     hints.ai_family = AF_UNSPEC;
     hints.ai_socktype = SOCK_STREAM;
     int err = getaddrinfo(provider, "80", &hints, &res);
     if (err) {
         WARN("Error getting address info: %s\n", gai_strerror(err));
-        return -1;
+        goto end;
     }
     
     /* Create socket and connect */
@@ -84,31 +88,48 @@ static int get_weather(void) {
     
     if (sockfd == -1) {
         WARN("Error creating socket: %s\n", strerror(errno));
-        return -1;
+        goto end;
     }
     
     /* Send request */
     if (send(sockfd, header, sizeof(header), 0) == -1) {
         WARN("Error sending GET: %s\n", strerror(errno));
-        return -1;
+        goto end;
     }
     
     /* Receive data */
     char buf[BUFFER_SIZE] = {0};
     if (recv(sockfd, buf, sizeof(buf) - 1, 0) == -1) {
         WARN("Error receiving data: %s\n", strerror(errno));
-        return -1;
+        goto end;
     }
     
     if (!strstr(buf, "\"clouds\"")) {
-        WARN("Json does not contain clouds information.\n");
-        return -1;
+        if (strstr(buf, "\"message\"")) {
+            char *message = strstr(buf, "\"message\"") + strlen("\"message\"") + 3; // remove " \"" (space + opening ")
+            char *ptr = strchr(message, '\"');
+            if (ptr) {
+                *ptr = '\n'; // remove closing " and put \n
+                if (*(ptr + 1)) {
+                    *(ptr + 1) = '\0'; // remove closing }
+                }
+            }
+            WARN(message);
+        } else {
+            WARN("Json does not contain clouds information.\n");
+        }
+        goto end;
     }
     
+    ret = 0;
     sscanf(strstr(buf, "\"clouds\""), "\"clouds\":{\"all\":%d}", &state.cloudiness);
     DEBUG("Cloudiness: %d\n", state.cloudiness);
-    close(sockfd);
-    return 0;
+    
+end:
+    if (sockfd > 0) { 
+        close(sockfd);
+    }
+    return ret;
 }
 
 static void upower_callback(const void *ptr) {


### PR DESCRIPTION
Added an OpenWeatherMap weather module, disabled by default.
To enable it, set your openweathermap apikey in conf file.
When weather module is enabled, timeouts between captures will take into account current cloudiness, by shortening timeouts when cloudiness is > 50 (as obviously there will surely be more frequent ligth changes).

Moreover, added a network module too, that listens on NetworkManager StateChanged signals, and starts/stops weather module when needed. Obviously it is optional.

Fixed some bugs too.