### PR TITLE
Specify desktop icon without extension

### DIFF
--- a/Extra/desktop/clightc.desktop
+++ b/Extra/desktop/clightc.desktop
@@ -4,7 +4,7 @@ Name=Clight
 GenericName=Quick screen backlight calibration
 Exec=busctl --expect-reply=false --user call org.clight.clight /org/clight/clight org.clight.clight Calibrate
 Comment=Recalibrate your screen backlight!
-Icon=clight.svg
+Icon=clight
 Categories=System
 Actions=Inhibit;Uninhibit;PauseCalib;ResumeCalib
 


### PR DESCRIPTION
I've recently worked on packaging clight and its dependencies for Gentoo, and I got the following QA warning upon installation:

> As described in the Icon Theme Specification, icon file extensions are not allowed in .desktop files if the value is not an absolute path.

Apparently freedesktop.org's Icon Theme Specification describes an [icon lookup mechanism](https://specifications.freedesktop.org/icon-theme-spec/icon-theme-spec-latest.html#icon_lookup) that tries to locate icon files with multiple extension when the icon is not specified as an absolute path.

I had to write the patch for the Gentoo package anyway, and I decided to send it upstream as well. Hope you find it useful too!