### PR TITLE
Don't reset DPMS settings if DIMMER is disabled

### DIFF
--- a/src/conf/opts.c
+++ b/src/conf/opts.c
@@ -384,14 +384,16 @@ static void check_dpms_conf(dpms_conf_t *dpms_conf) {
         dpms_conf->disabled = true;
     }
     
-    if (dpms_conf->timeout[ON_AC] <= conf.dim_conf.timeout[ON_AC]) {
-        WARN("DPMS AC timeout: wrong value (<= dimmer timeout). Resetting default value.\n");
-        dpms_conf->timeout[ON_AC] = 900;
-    }
-    
-    if (dpms_conf->timeout[ON_BATTERY] <= conf.dim_conf.timeout[ON_BATTERY]) {
-        WARN("DPMS BATT timeout: wrong value (<= dimmer timeout). Resetting default value.\n");
-        dpms_conf->timeout[ON_BATTERY] = 300;
+    if (!conf.dim_conf.disabled) {
+        if (dpms_conf->timeout[ON_AC] <= conf.dim_conf.timeout[ON_AC]) {
+            WARN("DPMS AC timeout: wrong value (<= dimmer timeout). Resetting default value.\n");
+            dpms_conf->timeout[ON_AC] = 900;
+        }
+        
+        if (dpms_conf->timeout[ON_BATTERY] <= conf.dim_conf.timeout[ON_BATTERY]) {
+            WARN("DPMS BATT timeout: wrong value (<= dimmer timeout). Resetting default value.\n");
+            dpms_conf->timeout[ON_BATTERY] = 300;
+        }
     }
 }
 


### PR DESCRIPTION
This PR is a quick attempt to fix #121. It makes sure that a disabled DIMMER module does not have a side effect on the settings of the DPMS module.

@FedeDP: hope it's a good enough fix like that, let me know if you had something else in mind!