### PR TITLE
docs: Fix a few typos

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 ### Keyboard
 - [x] Add curve configuration
 - [x] Use curve config
-- [x] drop ambient_threshol
+- [x] drop ambient_threshold
 - [x] Expose curve points from dbus (read only)
 - [x] allow to update them from dbus
 

--- a/src/conf/opts.c
+++ b/src/conf/opts.c
@@ -235,7 +235,7 @@ static void parse_cmd(int argc, char *const argv[], char *conf_file, size_t size
     }
     /*
      * poptGetNextOpt returns -1 when the final argument has been parsed
-     * otherwise an error occured
+     * otherwise an error occurred
      */
     poptFreeContext(pc);
     if (rc != -1) {

--- a/src/main.c
+++ b/src/main.c
@@ -79,7 +79,7 @@ static void init(int argc, char *argv[]) {
         * thus one can override a global module (placed in /usr/share/clight/modules.d/)
         * by creating a module with same name in $HOME.
         * 
-        * Clight internal modules cannot be overriden.
+        * Clight internal modules cannot be overridden.
         */
         load_user_modules(LOCAL);
         load_user_modules(GLOBAL);

--- a/src/modules/interface.c
+++ b/src/modules/interface.c
@@ -164,7 +164,7 @@ static void init(void) {
         if (r < 0) {
             WARN("Failed to create %s dbus interface: %s\n", bus_interface, strerror(-r));
         } else {
-            /* Subscribe to any topic expept REQUESTS */
+            /* Subscribe to any topic except REQUESTS */
             m_subscribe("^[^Req].*");
             
             /** org.freedesktop.ScreenSaver API **/

--- a/src/modules/pm.c
+++ b/src/modules/pm.c
@@ -40,7 +40,7 @@ static bool evaluate() {
 static void receive(const msg_t *const msg, UNUSED const void* userdata) {
     switch (MSG_TYPE()) {
         case FD_UPD: {
-            /* We are reading a message delyaed of conf.resumedelay */
+            /* We are reading a message delayed of conf.resumedelay */
             message_t *suspend_msg = (message_t *)msg->fd_msg->userptr;
             read_timer(delayed_resume_fd);
             M_PUB(suspend_msg);

--- a/src/public.h
+++ b/src/public.h
@@ -78,9 +78,9 @@ enum mod_msg_types {
     IN_EVENT_UPD,       // Subscribe to receive new InEvent states
     SUNRISE_UPD,        // Subscribe to receive new Sunrise times
     SUNSET_UPD,         // Subscribe to receive new Sunset times
-    TEMP_UPD,           // Subscribe to receive new gamma temperatures. NOTE: for smooth changes, a first TEMP_UPD will be emitteed with target temp and smooth params, then for each individual step TEMP_UPD will be emitted too
+    TEMP_UPD,           // Subscribe to receive new gamma temperatures. NOTE: for smooth changes, a first TEMP_UPD will be emitted with target temp and smooth params, then for each individual step TEMP_UPD will be emitted too
     AMBIENT_BR_UPD,     // Subscribe to receive new ambient brightness values
-    BL_UPD,             // Subscribe to receive new backlight level values. NOTE: for smooth changes, a first BL_UPD will be emitteed with target temp and smooth params, then for each individual step BL_UPD will be emitted too
+    BL_UPD,             // Subscribe to receive new backlight level values. NOTE: for smooth changes, a first BL_UPD will be emitted with target temp and smooth params, then for each individual step BL_UPD will be emitted too
     KBD_BL_UPD,         // Subscribe to receive new keyboard backlight values
     SCR_BL_UPD,         // Subscribe to receive new screen-emitted brightness values
     LOCATION_REQ,       // Publish to set a new location
@@ -108,7 +108,7 @@ enum mod_msg_types {
     SENS_UPD,           // Subscribe to receive "SensorAvail" states
     NEXT_DAYEVT_UPD,    // Subscribe to receive notifications about next day event (ie: sunrise or sunset)
     SUSPEND_UPD,        // Subscribe to receive new system suspended states
-    SUSPEND_REQ,        // Publish to set a new system suspend state (this won't suspend your system! It jsut 'fakes' a suspended state)
+    SUSPEND_REQ,        // Publish to set a new system suspend state (this won't suspend your system! It just 'fakes' a suspended state)
     KBD_TO_REQ,         // Publish to require a new keyboard timeout
     AMB_GAMMA_REQ,      // Publish to require a new AmbientGamma state
     KBD_CURVE_REQ,      // Publish to set a new keyboard backlight curve for given ac state


### PR DESCRIPTION
There are small typos in:
- TODO.md
- src/conf/opts.c
- src/main.c
- src/modules/interface.c
- src/modules/pm.c
- src/public.h

Fixes:
- Should read `emitted` rather than `emitteed`.
- Should read `threshold` rather than `threshol`.
- Should read `overridden` rather than `overriden`.
- Should read `occurred` rather than `occured`.
- Should read `just` rather than `jsut`.
- Should read `except` rather than `expept`.
- Should read `delayed` rather than `delyaed`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md