### PR TITLE
update freedesktop api

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,9 @@
 ### Signal
 - [x] Improve signal support, adding SIGUSR1 to trigger a capture, SIGTSTP to pause and SIGCONT to resume
 
+### Pm
+- [x] add support for logind inhibition
+
 ## 4.11
 
 ### Backlight

--- a/src/modules/pm.c
+++ b/src/modules/pm.c
@@ -147,15 +147,10 @@ static int on_logind_change(UNUSED sd_bus_message *m, UNUSED void *userdata, UNU
 }
 
 static int parse_bus_reply(sd_bus_message *reply, const char *member, void *userdata) {
-    int r = -EINVAL;
-    if (strcmp(member, "Inhibit") != 0) {
-        r = sd_bus_message_read(reply, "u", userdata);
-    } else {
-        unsigned int f;
-        r = sd_bus_message_read(reply, "h", &f);
-        if (r >= 0) {
-            pm_inh_token = fcntl(f, F_DUPFD_CLOEXEC, 3);
-        }
+    unsigned int f;
+    int r = sd_bus_message_read(reply, "h", &f);
+    if (r >= 0) {
+        pm_inh_token = fcntl(f, F_DUPFD_CLOEXEC, 3);
     }
     return r;
 }

--- a/src/modules/pm.c
+++ b/src/modules/pm.c
@@ -145,17 +145,16 @@ static void publish_susp_req(const bool new) {
 }
 
 static bool acquire_lock(void) {
-    static bool r = false;
+    bool r = false;
     if (pm_inh_token == -1) {
-        SYSBUS_ARG_REPLY(pm_args, parse_bus_reply, &pm_inh_token, "org.freedesktop.login1", "/org/freedesktop/login1",
+        SYSBUS_ARG_REPLY(pm_args, parse_bus_reply, &pm_inh_token,
+                         "org.freedesktop.login1", "/org/freedesktop/login1",
                          "org.freedesktop.login1.Manager", "Inhibit");
-
-        int ret = call(&pm_args, "ssss", "idle", "Clight", "Idle inhibitor.", "block");
-
+        int ret = call(&pm_args, "ssss", "idle", "Clight", "Idle inhibitor.",
+                       "block");
         if (ret < 0) {
             DEBUG("Failed to parse D-Bus response for idle inhibit\n");
         }
-
         if (pm_inh_token < 0) {
             DEBUG("Failed to copy lock file\n");
         } else {

--- a/src/modules/pm.c
+++ b/src/modules/pm.c
@@ -136,12 +136,11 @@ static int parse_bus_reply(sd_bus_message *reply, const char *member,
         int r = sd_bus_message_read(reply, "h", &f);
         if (r >= 0) {
             pm_inh_token = fcntl(f, F_DUPFD_CLOEXEC, 3);
-            return r;
         }
+        return r;
     }
     case POWERMANAGEMENT: {
-        int r = sd_bus_message_read(reply, "u", userdata);
-        return r;
+        return sd_bus_message_read(reply, "u", userdata);
     }
     case NONE: {
         return -EINVAL;
@@ -164,41 +163,36 @@ static void publish_susp_req(const bool new) {
 }
 
 static bool acquire_systemd_lock(void) {
-    inh_api = SYSTEMD;
     SYSBUS_ARG_REPLY(pm_args, parse_bus_reply, &pm_inh_token,
                      "org.freedesktop.login1", "/org/freedesktop/login1",
                      "org.freedesktop.login1.Manager", "Inhibit");
-    int ret =
-        call(&pm_args, "ssss", "idle", "Clight", "Idle inhibitor.", "block");
-    if (ret < 0) {
-        inh_api = NONE;
-        DEBUG("Failed to parse systemd-inhibit D-Bus response.\n");
-    } else if (pm_inh_token < 0) {
-        inh_api = NONE;
-        DEBUG("Failed to copy lock file\n");
-    } else {
+    int ret = call(&pm_args, "ssss", "idle", "Clight", "Idle inhibitor.", "block");
+    if (ret == 0 && pm_inh_token > 0) {
         DEBUG("Holding inhibition with systemd-inhibit.\n");
+        inh_api = SYSTEMD;
         return true;
     }
-    inh_api = NONE;
+    
+    if (ret < 0) {
+        DEBUG("Failed to parse systemd-inhibit D-Bus response.\n");
+    } else {
+        DEBUG("Failed to copy lock file\n");
+    }
     return false;
 }
 
 static bool acquire_pm_lock(void) {
-    inh_api = POWERMANAGEMENT;
     SYSBUS_ARG_REPLY(pm_args, parse_bus_reply, &pm_inh_token,
                      "org.freedesktop.PowerManagement.Inhibit",
                      "/org/freedesktop/PowerManagement/Inhibit",
                      "org.freedesktop.PowerManagement.Inhibit", 
                      "Inhibit");
-    if (call(&pm_args, "ss", "Clight", "Idle inhibitor.", "block") != 0) {
-        DEBUG("Failed to parse PowerManagement D-Bus response.\n");
-        inh_api = NONE;
-    } else {
+    if (call(&pm_args, "ss", "Clight", "Idle inhibitor.", "block") == 0) {
         DEBUG("Holding inhibition with PowerManagement.\n");
+        inh_api = POWERMANAGEMENT;
         return true;
     }
-    inh_api = NONE;
+    DEBUG("Failed to parse PowerManagement D-Bus response.\n");
     return false;
 }
 


### PR DESCRIPTION
The PowerManagement api seems to be deprecated,
https://www.freedesktop.org/wiki/Specifications/power-management-spec/

This commit updates the current pm module to use the
org.freedesktop.login1.Manager.Inhibit api. This also has the
benefit of working with swayidle.

a bit unrelated, but I'm thinking of working on a wayland
specific pm module that will rely on
https://wayland.app/protocols/idle-inhibit-unstable-v1

Would you be interested in this?