### PR TITLE
new: added a new  config: `hotplug_delay`

### DIFF
--- a/Extra/clight.conf
+++ b/Extra/clight.conf
@@ -95,6 +95,13 @@ backlight:
     
     ## Uncomment to let BACKLIGHT module fire an automatic calibration when laptop lid gets opened.
     # capture_on_lid_opened = true;
+    
+    ## Uncomment to set a delay before GAMMA and BACKLIGHT get synced
+    ## whenever a monitor is added/removed.
+    ## Similarly to "resumedelay", some monitors are slow to become active,
+    ## therefore a small delay is needed.
+    ## By default, it is disabled (0 seconds). Max value: 10seconds.
+    # hotplug_delay = 5;
 };
 
 ###################

--- a/TODO.md
+++ b/TODO.md
@@ -12,6 +12,10 @@
 ### Screen
 - [x] fix screen_br reset upon pause
 
+### Backlight
+- [x] Refresh gamma on interface removed too
+- [x] wait some time (configurable) before refreshing gamma/backlight on interface changes
+
 ## 4.11
 
 ### Backlight

--- a/src/commons.h
+++ b/src/commons.h
@@ -59,6 +59,7 @@ typedef struct {
     int pause_on_lid_closed;                // whether clight should inhibit autocalibration on lid closed
     int capture_on_lid_opened;              // whether to trigger a new capture whenever lid gets opened
     int restore;                            // whether backlight should be restored on Clight exit
+    int sync_monitors_delay;                // delay before syncing gamma and backlight when monitors are hotplugged
 } bl_conf_t;
 
 typedef struct {

--- a/src/conf/config.c
+++ b/src/conf/config.c
@@ -56,7 +56,8 @@ static void load_backlight_settings(config_t *cfg, bl_conf_t *bl_conf) {
         config_setting_lookup_bool(bl, "no_auto_calibration", &bl_conf->no_auto_calib);
         config_setting_lookup_bool(bl, "pause_on_lid_closed", &bl_conf->pause_on_lid_closed);
         config_setting_lookup_bool(bl, "capture_on_lid_opened", &bl_conf->capture_on_lid_opened);
-        
+        config_setting_lookup_int(bl, "hotplug_delay", &bl_conf->sync_monitors_delay);
+         
         config_setting_t *timeouts;
         
         /* Load capture timeouts while on battery -> +1 because EVENT is exposed too */
@@ -467,6 +468,9 @@ static void store_backlight_settings(config_t *cfg, bl_conf_t *bl_conf) {
 
     setting = config_setting_add(bl, "shutter_threshold", CONFIG_TYPE_FLOAT);
     config_setting_set_float(setting, bl_conf->shutter_threshold);
+    
+    setting = config_setting_add(bl, "hotplug_delay", CONFIG_TYPE_INT);
+    config_setting_set_int(setting, bl_conf->sync_monitors_delay);
     
     setting = config_setting_add(bl, "ac_timeouts", CONFIG_TYPE_ARRAY);
     for (int i = 0; i < SIZE_STATES + 1; i++) {

--- a/src/conf/opts.c
+++ b/src/conf/opts.c
@@ -45,6 +45,7 @@ static void init_backlight_opts(bl_conf_t *bl_conf) {
     bl_conf->timeout[ON_BATTERY][IN_EVENT] = 2 * conf.bl_conf.timeout[ON_AC][IN_EVENT];
     bl_conf->smooth.trans_step = 0.05;
     bl_conf->smooth.trans_timeout = 30;
+    bl_conf->sync_monitors_delay = 5;
 }
 
 static void init_sens_opts(sensor_conf_t *sens_conf) {
@@ -294,6 +295,11 @@ static void check_bl_conf(bl_conf_t *bl_conf) {
     if (bl_conf->shutter_threshold < 0 || bl_conf->shutter_threshold >= 1) {
         WARN("BL_CONF: wrong 'shutter_threshold' value. Resetting default value.\n");
         bl_conf->shutter_threshold = 0.0;
+    }
+    
+    if (bl_conf->sync_monitors_delay < 0 || bl_conf->sync_monitors_delay > 10) {
+        WARN("BL_CONF: wrong 'hotplug_delay' value. Resetting default value.\n");
+        bl_conf->sync_monitors_delay = 0;
     }
 }
 

--- a/src/conf/opts.c
+++ b/src/conf/opts.c
@@ -45,7 +45,6 @@ static void init_backlight_opts(bl_conf_t *bl_conf) {
     bl_conf->timeout[ON_BATTERY][IN_EVENT] = 2 * conf.bl_conf.timeout[ON_AC][IN_EVENT];
     bl_conf->smooth.trans_step = 0.05;
     bl_conf->smooth.trans_timeout = 30;
-    bl_conf->sync_monitors_delay = 5;
 }
 
 static void init_sens_opts(sensor_conf_t *sens_conf) {

--- a/src/utils/log.c
+++ b/src/utils/log.c
@@ -62,6 +62,7 @@ static void log_bl_conf(bl_conf_t *bl_conf) {
     fprintf(log_file, "* Pause on lid closed:\t\t%s\n", bl_conf->pause_on_lid_closed ? "Enabled" : "Disabled");
     fprintf(log_file, "* Capture on lid opened:\t\t%s\n", bl_conf->capture_on_lid_opened ? "Enabled" : "Disabled");
     fprintf(log_file, "* Restore On Exit:\t\t%s\n", bl_conf->restore ? "Enabled" : "Disabled");
+    fprintf(log_file, "* Delay on hotplug:\t\t%d\n", bl_conf->sync_monitors_delay);
 }
 
 static void log_sens_conf(sensor_conf_t *sens_conf) {


### PR DESCRIPTION
* `hotplug_delay` adds a small delay before syncing gamma and backlight on monitors hotplug (ie: both added or deleted)
* moreover, enforce proper gamma even on monitor deletion (previously gamma was only synced on monitor added)