### PR TITLE
Fix backlight flickering and suspend/resume state machine

### DIFF
--- a/src/modules/backlight.c
+++ b/src/modules/backlight.c
@@ -514,14 +514,17 @@ static void set_new_backlight(void) {
         DEBUG("Content calib: wmax: %.3lf, wmin: %.3lf, new_bl: %.3lf\n", 
               wmax, wmax - 2 * conf.screen_conf.contrib, bl_req.bl.new);
     }
+    bool should_update_bl = (fabs(bl_req.bl.new - state.current_bl_pct) >= conf.bl_conf.smooth.trans_step);
     // Less verbose: only log real backlight changes, unless we are in verbose mode
-    if (bl_req.bl.new != state.current_bl_pct || conf.verbose) {
+    if (should_update_bl || conf.verbose) {
         if (state.screen_br == 0.0f) {
             INFO("Ambient brightness: %.3lf -> Screen backlight: %.3lf.\n", state.ambient_br, bl_req.bl.new);
         } else {
             INFO("Ambient brightness: %.3lf, Screen brightness: %.3lf -> Screen backlight: %.3lf.\n", 
                  state.ambient_br, state.screen_br, bl_req.bl.new);
         }
+    }
+    if (should_update_bl) {
         M_PUB(&bl_req);
     }
 }

--- a/src/modules/pm.c
+++ b/src/modules/pm.c
@@ -262,10 +262,10 @@ static void on_suspend_req(suspend_upd *up) {
                 M_PUB(suspend_msg);
             }
         }
+
+       /* Count currently held suspends */
+        if (up->new) {
+            suspend_ctr++;
+        }
     }
-    /* Count currently held suspends */
-    if (up->new) {
-        suspend_ctr++;
-    }
-    DEBUG("Suspend ctr: %d\n", suspend_ctr);
 }


### PR DESCRIPTION
### backlight: prevent continuous backlight adjustments
Due to floating-point precision and the nature of trans_step calculations, bl_req.bl.new and state.current_bl_pct may frequently differ by small amounts, potentially causing continuous backlight adjustments.

By introducing a threshold check based on the smooth transition step size, the system now only updates the backlight when there is a meaningful change, effectively eliminating the flickering effect that was previously observed.

```
Ambient brightness: 0.391 -> Screen backlight: 0.589.
Backlight 'backlight-lcd' level updated: 0.59.
Backlight 'backlight-lcd' level updated: 0.54.
Backlight 'backlight-lcd' level updated: 0.59.
Backlight 'backlight-lcd' level updated: 0.54.
........endless loop
```

###  pm: fix suspend counter increment only on successful validation
   
    Before fix: Multiple resume requests needed to match pause count
    After fix: Single resume request properly exits suspended state
    Reproduce sequence:
```
    busctl --user call org.clight.clight /org/clight/clight org.clight.clight Pause b true
    busctl --user call org.clight.clight /org/clight/clight org.clight.clight Pause b true
    busctl --user call org.clight.clight /org/clight/clight org.clight.clight Pause b true
    busctl --user call org.clight.clight /org/clight/clight org.clight.clight Pause b true
    busctl --user call org.clight.clight /org/clight/clight org.clight.clight Pause b true
    
    busctl --user call org.clight.clight /org/clight/clight org.clight.clight Pause b false
    busctl --user call org.clight.clight /org/clight/clight org.clight.clight Pause b false
    busctl --user call org.clight.clight /org/clight/clight org.clight.clight Pause b false
    busctl --user call org.clight.clight /org/clight/clight org.clight.clight Pause b false
    busctl --user introspect org.clight.clight /org/clight/clight | grep Suspended
    .Suspended                          property  b         true           emits-change
    busctl --user call org.clight.clight /org/clight/clight org.clight.clight Pause b false
    busctl --user introspect org.clight.clight /org/clight/clight | grep Suspended
    .Suspended                          property  b         false          emits-change
```