### PR TITLE
Add DIY Ambient Light Sensor section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ On wayland Clight requires specific protocols to be implemented by your composit
 Github user [nullobsi](https://github.com/nullobsi) created a (super nice!) qt gui for clight, with a useful tray applet too.  
 Remember to check it out: https://github.com/nullobsi/clight-gui!
 
+## DIY Ambient Light Sensor
+
+For desktops without a built-in ambient light sensor or webcam, you can build your own USB ambient light sensor using a Raspberry Pi Pico. Check out the project here: https://github.com/thariq-shanavas/RP2040_USBHID_Ambient-Light-Sensor
+
 ## Developers Corner
 
 Clight makes use of [Clightd](https://github.com/FedeDP/Clightd), a system DBus service that exposes an [API](https://github.com/FedeDP/Clightd/wiki/Api) to manage various aspects of your screen and allows Webcam/ALS devices captures.  


### PR DESCRIPTION
Thank you for your work on this wonderful project!

I had somewhat inconsistent results using a webcam and wanted to use an ALS sensor for my desktop. Unfortunately, there are very few choices for plug-and-play USB ambient light sensors on the market. The only option I could find, the Yoctolight sensor, can be prohibitively expensive to ship outside Europe. So I built a USB HID ALS sensor using parts that are inexpensive and easy to source in most of the world.

[Github Link](https://github.com/thariq-shanavas/RP2040_USBHID_Ambient-Light-Sensor)

<img width="250"  alt="image" src="https://github.com/user-attachments/assets/bf598746-4094-4264-811b-b89f99ac757d" />

<img width="250" alt="image" src="https://github.com/user-attachments/assets/c0f82752-41af-40b9-b9ea-df6b15a0aceb" />

If there is a more appropriate place to link to the project in the wiki, or if you would like to change the wording, please feel free to make changes.