### PR TITLE
Fix backlight/dimmer issues and config parsing bugs

### DIFF
--- a/src/conf/config.c
+++ b/src/conf/config.c
@@ -278,7 +278,7 @@ static void load_dimmer_settings(config_t *cfg, dimmer_conf_t *dim_conf) {
         if ((points = config_setting_get_member(dim, "no_smooth_transition"))) {
             if (config_setting_length(points) == SIZE_DIM) {
                 for (int i = 0; i < SIZE_DIM; i++) {
-                    dim_conf->smooth[i].no_smooth = config_setting_get_float_elem(points, i);
+                    dim_conf->smooth[i].no_smooth = config_setting_get_bool_elem(points, i);
                 }
             } else {
                 WARN("Wrong number of dimmer 'no_smooth_transition' array elements.\n");

--- a/src/modules/backlight.c
+++ b/src/modules/backlight.c
@@ -460,9 +460,9 @@ static int parse_bus_reply(sd_bus_message *reply, const char *member, void *user
     } else if (!strcmp(member, "Get")) {
         r = sd_bus_message_enter_container(reply, SD_BUS_TYPE_ARRAY, "(sd)");
         if (r == 1) {
-            while ((r = sd_bus_message_enter_container(reply, SD_BUS_TYPE_STRUCT, "sd") == 1)) {
+            while ((r = sd_bus_message_enter_container(reply, SD_BUS_TYPE_STRUCT, "sd")) == 1) {
                 const char *mon_id = NULL;
-                double *pct = malloc(sizeof(double)),
+                double *pct = malloc(sizeof(double));
                 r = sd_bus_message_read(reply, "sd", &mon_id, pct);
                 if (r >= 0) {
                     char key[PATH_MAX + 1];

--- a/src/modules/backlight.c
+++ b/src/modules/backlight.c
@@ -397,9 +397,14 @@ static void receive_paused(const msg_t *const msg, UNUSED const void* userdata) 
         break;
     }
     case BL_REQ: {
-        /* In paused state check that we're not dimmed/dpms */
+        /*
+         * In paused state, ignore normal autocalibration requests but still
+         * honor explicit dimmer enter/exit transitions.
+         */
         bl_upd *up = (bl_upd *)MSG_DATA();
-        if (VALIDATE_REQ(up) && !state.display_state) {
+        const int requested_smooth = up->smooth;
+        const bool dimmer_transition = requested_smooth == -2 || requested_smooth == -3;
+        if (VALIDATE_REQ(up) && (!state.display_state || dimmer_transition)) {
             set_backlight_level(up->new, up->smooth, up->step, up->timeout);
         }
         break;

--- a/src/modules/backlight.c
+++ b/src/modules/backlight.c
@@ -236,7 +236,8 @@ static void receive_waiting_init(const msg_t *const msg, UNUSED const void* user
              * Note: set smooth field from conf to allow keyboard and gamma to react;
              * > if (up->smooth || conf.bl_conf.no_smooth) { ... }
              */
-            set_backlight_level(1.0, !conf.bl_conf.smooth.no_smooth, 0, 0);
+            if (!conf.bl_conf.restore)
+                set_backlight_level(1.0, !conf.bl_conf.smooth.no_smooth, 0, 0);
             pause_mod(AUTOCALIB);
         }
         if (state.lid_state) {
@@ -250,6 +251,23 @@ static void receive_waiting_init(const msg_t *const msg, UNUSED const void* user
         // Store current backlight to later restore them if requested
         SYSBUS_ARG_REPLY(args, parse_bus_reply, NULL, CLIGHTD_SERVICE, "/org/clightd/clightd/Backlight2", "org.clightd.clightd.Backlight2", "Get");
         call(&args, NULL);
+
+        /*
+         * When restore_on_exit is set and auto calibration is disabled,
+         * initialize current_bl_pct from hardware so DIMMER knows
+         * the correct brightness to restore after dimming.
+         */
+        if (conf.bl_conf.no_auto_calib && conf.bl_conf.restore && map_length(bls) > 0) {
+            map_itr_t *itr = map_itr_new(bls);
+            if (itr) {
+                double *val = map_itr_get_data(itr);
+                if (val) {
+                    state.current_bl_pct = *val;
+                    DEBUG("Initial backlight level: %.2lf.\n", state.current_bl_pct);
+                }
+                free(itr);
+            }
+        }
     }
 }
 
@@ -544,6 +562,10 @@ static void publish_bl_upd(const double pct, const bool is_smooth, const double 
     M_PUB(bl_msg);
 }
 
+static int noop_reply_cb(UNUSED sd_bus_message *reply, UNUSED const char *member, UNUSED void *userdata) {
+    return 0;
+}
+
 static void set_each_brightness(double pct, const double step, const int timeout) {
     const bool restoring = pct == -1.0f;
     sensor_conf_t *sens_conf = &conf.sens_conf;
@@ -571,8 +593,14 @@ static void set_each_brightness(double pct, const double step, const int timeout
             r = call(&args, "d(du)", real_pct, step, timeout);
         } else {
             DEBUG("Using default curve for '%s'\n", mon_id);
-            /* Use non-adjusted (default) curve value */
-            r = call(&args, "d(du)", restoring ? *val : pct, step, timeout);
+            if (restoring) {
+                /* Synchronous call to ensure completion before exit */
+                SYSBUS_ARG_REPLY(sync_args, noop_reply_cb, NULL, CLIGHTD_SERVICE, path, "org.clightd.clightd.Backlight2.Server", "Set");
+                r = call(&sync_args, "d(du)", *val, step, timeout);
+            } else {
+                /* Use non-adjusted (default) curve value */
+                r = call(&args, "d(du)", pct, step, timeout);
+            }
         }
         if (r < 0) {
             WARN("Failed to set backlight on %s.\n", mon_id);

--- a/src/modules/backlight.c
+++ b/src/modules/backlight.c
@@ -771,6 +771,16 @@ static int on_bl_changed(sd_bus_message *m, UNUSED void *userdata, UNUSED sd_bus
     
     DEBUG("Backlight '%s' level updated: %.2lf.\n", syspath, pct);
     
+    /* Keep bls map in sync for restore_on_exit, but skip dimmed/dpms states */
+    if (!state.display_state) {
+        char key[PATH_MAX + 1];
+        make_valid_obj_path(key, sizeof(key), "/org/clightd/clightd/Backlight2", syspath);
+        double *val = map_get(bls, key);
+        if (val) {
+            *val = pct;
+        }
+    }
+
     /* Publish a single bl update event on multimonitor setups */
     if (!strcmp(backlight_interface, syspath)) {
         publish_bl_upd(pct, false, 0, 0);

--- a/src/modules/backlight.c
+++ b/src/modules/backlight.c
@@ -466,7 +466,7 @@ static int parse_bus_reply(sd_bus_message *reply, const char *member, void *user
                 r = sd_bus_message_read(reply, "sd", &mon_id, pct);
                 if (r >= 0) {
                     char key[PATH_MAX + 1];
-                    snprintf(key, sizeof(key), "/org/clightd/clightd/Backlight2/%s", mon_id);
+                    make_valid_obj_path(key, sizeof(key), "/org/clightd/clightd/Backlight2", mon_id);
                     map_put(bls, key, pct);
                 }
                 sd_bus_message_exit_container(reply);

--- a/src/modules/bus.c
+++ b/src/modules/bus.c
@@ -1,5 +1,6 @@
 #include "bus.h"
 #include "utils.h"
+#include <ctype.h>
 
 #define GET_BUS(a)  sd_bus *tmp = a->bus; if (!tmp) { tmp = a->type == USER_BUS ? userbus : sysbus; } if (!tmp) { return -1; }
 
@@ -205,4 +206,18 @@ static int proxy_async_request(struct sd_bus_message *m, void *userdata, sd_bus_
 
 sd_bus *get_user_bus(void) {
     return userbus;
+}
+
+/*
+ * Build a valid D-Bus object path from root + basename.
+ * Replaces any char not in [A-Za-z0-9_] with '_'.
+ * Mirrors Clightd's make_valid_obj_path in bus_utils.c.
+ */
+void make_valid_obj_path(char *storage, size_t size, const char *root, const char *name) {
+    snprintf(storage, size, "%s/%s", root, name);
+    for (char *p = storage + strlen(root) + 1; *p; p++) {
+        if (!isalnum((unsigned char)*p) && *p != '_') {
+            *p = '_';
+        }
+    }
 }

--- a/src/modules/bus.h
+++ b/src/modules/bus.h
@@ -37,7 +37,7 @@ typedef struct {
 #define USERBUS_ARG(name, ...)  USERBUS_ARG_REPLY(name, NULL, NULL, __VA_ARGS__);
 #define SYSBUS_ARG(name, ...)   SYSBUS_ARG_REPLY(name, NULL, NULL, __VA_ARGS__);
 
-
+void make_valid_obj_path(char *storage, size_t size, const char *root, const char *name);
 int call(const bus_args *a, const char *signature, ...);
 int add_match(const bus_args *a, sd_bus_slot **slot, sd_bus_message_handler_t cb);
 int set_property(const bus_args *a, const char *type, const uintptr_t value);

--- a/src/modules/pm.c
+++ b/src/modules/pm.c
@@ -42,7 +42,12 @@ static bool check(void) {
 }
 
 static bool evaluate() {
-    return !conf.inh_conf.disabled;
+    /*
+     * PM module handles suspend/resume events (SUSPEND_REQ) and power
+     * management inhibition (PM_REQ). Suspend/resume must work regardless
+     * of inhibit configuration, so always enable this module.
+     */
+    return true;
 }
 
 static void receive(const msg_t *const msg, UNUSED const void* userdata) {

--- a/src/modules/wizard.c
+++ b/src/modules/wizard.c
@@ -229,7 +229,7 @@ static int parse_bus_reply(sd_bus_message *reply, const char *member, void *user
             r = sd_bus_message_read(reply, "sd", &sysname, NULL);
             if (r >= 0) {
                 char obj_path[PATH_MAX + 1];
-                snprintf(obj_path, sizeof(obj_path), "/org/clightd/clightd/Backlight2/%s", sysname);
+                make_valid_obj_path(obj_path, sizeof(obj_path), "/org/clightd/clightd/Backlight2", sysname);
                 bl_obj_path = strdup(obj_path);
             }
             sd_bus_message_exit_container(reply);


### PR DESCRIPTION
This PR contains several bug fixes discovered while integrating Clight into an embedded system:

### 1. Sanitize backlight D-Bus object path
Backlight sysnames containing invalid D-Bus path characters (e.g. `backlight-lcd`) caused path mismatch with Clightd, leading to wizard calibration failure and stale map entries.

### 2. Fix dimmer no_smooth_transition config parsing
Boolean array was parsed using `config_setting_get_float_elem()` instead of `config_setting_get_bool_elem()`.

### 3. Fix comma operator in parse_bus_reply
The comma instead of semicolon caused `pct` to be assigned the return value of `sd_bus_message_read()` instead of the malloc'd pointer.

### 4. Allow dimmer transitions while paused
Race condition between DISPLAY and BACKLIGHT modules prevented dimmer from actually lowering brightness when entering dimmed state.

### 5. Fix restore_on_exit with no_auto_calib mode
When both options are enabled, user expects brightness to be preserved throughout the session. Fixed startup forcing 100%, uninitialized `current_bl_pct`, and async D-Bus call on exit.

---

All patches have been tested on an embedded Linux system with `no_auto_calib = true` and `restore_on_exit = true`.
